### PR TITLE
Add WCOSS2 support

### DIFF
--- a/modulefiles/workflow_utils.wcoss2.lua
+++ b/modulefiles/workflow_utils.wcoss2.lua
@@ -1,0 +1,33 @@
+help([[
+Build environment for workflow utilities on WCOSS2
+]])
+
+load(pathJoin("PrgEnv-intel", "8.1.0"))
+load(pathJoin("craype", "2.7.10"))
+load(pathJoin("intel", "19.1.3.304"))
+load(pathJoin("cray-mpich", "8.1.9"))
+
+load(pathJoin("cmake", "3.20.2"))
+
+load(pathJoin("jasper", "2.0.25"))
+load(pathJoin("zlib", "1.2.11"))
+load(pathJoin("libpng", "1.6.37"))
+
+load(pathJoin("hdf5", "1.10.6"))
+load(pathJoin("netcdf", "4.7.4"))
+
+load(pathJoin("bacio", "2.4.1"))
+load(pathJoin("g2", "3.4.5"))
+load(pathJoin("ip", "3.3.3"))
+load(pathJoin("nemsio", "2.5.2"))
+load(pathJoin("sp", "2.3.3"))
+load(pathJoin("w3emc", "2.9.2"))
+load(pathJoin("w3nco", "2.4.1"))
+load(pathJoin("nemsiogfs", "2.5.3"))
+load(pathJoin("ncio", "1.0.0"))
+load(pathJoin("landsfcutil", "2.4.1"))
+load(pathJoin("sigio", "2.3.2"))
+load(pathJoin("bufr", "11.5.0"))
+load(pathJoin("gempak", "7.14.1"))
+
+load(pathJoin("wgrib2", "2.0.8"))

--- a/ush/machine-setup.sh
+++ b/ush/machine-setup.sh
@@ -20,7 +20,16 @@ target=""
 USERNAME=$(echo $LOGNAME | awk '{ print tolower($0)'})
 ##---------------------------------------------------------------------------
 export hname=$(hostname | cut -c 1,1)
-if [[ -d /work ]] ; then
+if [[ -d /lfs/f1 ]] ; then
+    # We are on NOAA Cactus or Dogwood
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        echo load the module command 1>&2
+        source /usr/share/lmod/lmod/init/$__ms_shell
+    fi
+    target=wcoss2
+    module reset
+
+elif [[ -d /work ]] ; then
     # We are on MSU Orion
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         echo load the module command 1>&2


### PR DESCRIPTION
This PR adds WCOSS2 support to `ush/machine-setup.sh` and creates `workflow_utils.wcoss2.lua`.

Tested this update within a global-workflow WCOSS2-supporting branch on Cactus.

Resolves #6