### PR TITLE
Remove the cmake module load from the s4 module

### DIFF
--- a/modulefiles/gfsutils_s4.lua
+++ b/modulefiles/gfsutils_s4.lua
@@ -9,7 +9,6 @@ load("license_intel")
 local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
 local hpc_intel_ver=os.getenv("hpc_intel_ver") or "18.0.4"
 local hpc_impi_ver=os.getenv("hpc_impi_ver") or "18.0.4"
-local cmake_ver=os.getenv("cmake_ver") or "3.20.1"
 
 local jasper_ver=os.getenv("jasper_ver") or "2.0.25"
 local zlib_ver=os.getenv("zlib_ver") or "1.2.11"
@@ -18,7 +17,6 @@ local libpng_ver=os.getenv("libpng_ver") or "1.6.35"
 load(pathJoin("hpc", hpc_ver))
 load(pathJoin("hpc-intel", hpc_intel_ver))
 load(pathJoin("hpc-impi", hpc_impi_ver))
-load(pathJoin("cmake", cmake_ver))
 
 load(pathJoin("jasper", jasper_ver))
 load(pathJoin("zlib", zlib_ver))


### PR DESCRIPTION
S4 does not have a module installed for cmake, so loading a modulefile for it should not be attempted.  The native version of cmake is 3.20.5.  This pull request thus removes the cmake load from the S4 modulefile.