### PR TITLE
Use module reset and fix Orion build

### DIFF
--- a/modulefiles/gfsutils_orion.lua
+++ b/modulefiles/gfsutils_orion.lua
@@ -2,9 +2,9 @@ help([[
 Build environment for GFS utilities on Orion
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/hpc-stack/libs/hpc-stack/modulefiles/stack")
 
-local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
+local hpc_ver=os.getenv("hpc_ver") or "1.2.0"
 local hpc_intel_ver=os.getenv("hpc_intel_ver") or "2018.4"
 local hpc_impi_ver=os.getenv("hpc_impi_ver") or "2018.4"
 local cmake_ver=os.getenv("cmake_ver") or "3.22.1"

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -30,7 +30,8 @@ elif [[ $MACHINE_ID = s4* ]] ; then
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /usr/share/lmod/lmod/init/bash
     fi
-    module purge
+    export LMOD_SYSTEM_DEFAULT_MODULES=license_intel
+    module reset
 
 elif [[ $MACHINE_ID = wcoss2 ]]; then
     # We are on WCOSS2

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -6,21 +6,24 @@ if [[ $MACHINE_ID = jet* ]] ; then
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/lmod/init/bash
     fi
-    module purge
+    export LMOD_SYSTEM_DEFAULT_MODULES=contrib
+    module reset
 
 elif [[ $MACHINE_ID = hera* ]] ; then
     # We are on NOAA Hera
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/lmod/init/bash
     fi
-    module purge
+    export LMOD_SYSTEM_DEFAULT_MODULES=contrib
+    module reset
 
 elif [[ $MACHINE_ID = orion* ]] ; then
     # We are on Orion
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/init/bash
     fi
-    module purge
+    export LMOD_SYSTEM_DEFAULT_MODULES=contrib
+    module reset
 
 elif [[ $MACHINE_ID = s4* ]] ; then
     # We are on SSEC Wisconsin S4


### PR DESCRIPTION
This PR resolves issues #13 and #14. This PR replaces `module purge` with `module reset` on Hera, Orion, Jet, and S4. This PR also fixes the build on Orion by moving to a different copy of hpc-stack (see more details in issue #14).

Close #13
Fixes #14