### PR TITLE
Update module file for Jet

### DIFF
--- a/modulefiles/gfsutils_jet.lua
+++ b/modulefiles/gfsutils_jet.lua
@@ -1,10 +1,10 @@
 help([[
-Build environment for S4 utilities on Jet
+Build environment for GFS utilities on Jet
 ]])
 
-prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack")
+prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/role.epic/hpc-stack/libs/intel-18.0.5.274/modulefiles/stack")
 
-local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
+local hpc_ver=os.getenv("hpc_ver") or "1.2.0"
 local hpc_intel_ver=os.getenv("hpc_intel_ver") or "18.0.5.274"
 local hpc_impi_ver=os.getenv("hpc_impi_ver") or "2018.4.274"
 local cmake_ver=os.getenv("cmake_ver") or "3.20.1"
@@ -20,7 +20,7 @@ load(pathJoin("cmake", cmake_ver))
 
 load(pathJoin("jasper", jasper_ver))
 load(pathJoin("zlib", zlib_ver))
-load(pathJoin("png", libpng_ver))
+load(pathJoin("libpng", libpng_ver))
 
 load("gfsutils_common")
 


### PR DESCRIPTION
EPIC has installed hpc-stack on Jet with Intel version 18.  The module file for Jet has thus been updated to point to that installation, which allows gfs-utils to build.  Fixes #10.