### PR TITLE
Extend max path length for bufr

### DIFF
--- a/src/gfs_bufr.fd/buff.f
+++ b/src/gfs_bufr.fd/buff.f
@@ -1,13 +1,12 @@
       subroutine buff(nint1,nend1,nint3,nend3,npoint,idate,jdate,levs,
      &           dird,lss,istat,sbset,seqflg,clist,npp,wrkd)
-      character*150 dird, fnbufr, fmto
+      character*512 dird, fnbufr, fmto
 !!      integer nint, nend, npoint, idate(4), levs, jdate
       integer nint1, nend1, nint3, nend3
       integer npoint, idate(4), levs, jdate
       real*8 data(6*levs+25), wrkd(1)
       integer idtln, nf, nfile, np
       integer lss, istat(npoint), ios
-      CHARACTER*150  FILESEQ
       CHARACTER*8      SBSET
       LOGICAL         SEQFLG(4)
       CHARACTER*80     CLIST(4)

--- a/src/gfs_bufr.fd/gfsbufr.f
+++ b/src/gfs_bufr.fd/gfsbufr.f
@@ -68,9 +68,8 @@ C$$$
       character*4 t3
       character*4 cstat(nsta)
       character*32 desc
-      character*150 dird, fnsig
+      character*512 dird, fnsig
       logical f00, makebufr
-      CHARACTER*150  FILESEQ
       CHARACTER*8      SBSET
       LOGICAL         SEQFLG(4)
       CHARACTER*80     CLIST(4)

--- a/src/gfs_bufr.fd/meteorg.f
+++ b/src/gfs_bufr.fd/meteorg.f
@@ -82,7 +82,7 @@
       integer :: idate(4),nij,nflx2,np,k,l,nf,nfhour,np1
       integer :: idate_nems(7)
       integer :: iret,jdate,leveta,lm,lp1
-      character*150 :: fnsig,fngrib
+      character*512 :: fnsig,fngrib
 !!      real*8 :: data(6*levs+25)
       real*8 :: data2(6*levso+25)
       real*8 :: rstat1


### PR DESCRIPTION
Workflow recently ran into issues with the string that holds the path not being long enough in bufr. These have now been increased from 150 characters to 512.

Also removes `FILESEQ`, which was defined but never used, rather than modifying.

Resolves #21