### PR TITLE
add 5deg as destination grid

### DIFF
--- a/src/ocnicepost.fd/init_mod.F90
+++ b/src/ocnicepost.fd/init_mod.F90
@@ -106,6 +106,7 @@ contains
     if (nxr == 1440 .and. nyr == 721) fdst = '0p25'      ! 1/4deg rectilinear
     if (nxr == 720  .and. nyr == 361) fdst = '0p5'       ! 1/2 deg rectilinear
     if (nxr == 360  .and. nyr == 181) fdst = '1p0'       ! 1 deg rectilinear
+    if (nxr == 72   .and. nyr == 36) fdst = '5p0'        ! 5 deg rectilinear
     if (len_trim(fdst) == 0) then
        write(logunit,'(a)')'destination grid dimensions unknown'
        stop


### PR DESCRIPTION
Issue https://github.com/NOAA-EMC/global-workflow/issues/1992 has been created to add the ESMF weights needed for the 5-deg destination grid to the g-w fix file locations. A one-line change in ocnicepost is required to add the 5-deg rectilinear as a destination grid. 