### PR TITLE
ENH: Allow ush/finddate.sh to handle multiple month boundaries

### DIFF
--- a/ush/finddate.sh
+++ b/ush/finddate.sh
@@ -37,17 +37,6 @@ function isleap() {
     test "${isleap}" -eq 1
 }
 
-# for year in $(seq 1995 2005) $(seq 2095 2105);
-# do
-#     if isleap "${year}";
-#     then
-# 	echo "${year} is a leap year"
-#     else
-# 	echo "${year} is not a leap year"
-#     fi
-# done
-
-
 # Takes four-digit year and two-digit month as argument
 # Prints days in that month to stdout
 function days_per_month() {
@@ -72,12 +61,6 @@ function days_per_month() {
 	    exit 1
     esac
 }
-
-# for year_month in $(seq 202101 202112) $(seq 199502 100 200502) 210002;
-# do
-#     echo -n "Days in ${year_month}: "
-#     days_per_month $(($year_month / 100)) $(($year_month % 100))
-# done
 
 # Takes four-digit year, month, day and days ahead as arguments
 # Prints date the given number of days after the given date in YYYYMMDD format to stdout
@@ -118,25 +101,6 @@ function n_days_ahead() {
     printf '%04d%02d%02d' "${year}" "${month}" "${day}"
 }
 
-# for startday in 20210501 20191201;
-# do
-#     for ndays in $(seq 55 65) $(seq 85 95) 365 730;
-#     do
-# 	echo -n "${ndays} days after ${startday} is "
-# 	n_days_ahead "${startday:0:4}" "${startday:4:2}" "${startday:6:2}" "${ndays}"
-# 	echo
-#     done
-#     echo
-#
-#     for ndays in $(seq 55 65) $(seq 85 95) 365 730;
-#     do
-# 	echo -n "${ndays} days before ${startday} is "
-# 	n_days_ahead "${startday:0:4}" "${startday:4:2}" "${startday:6:2}" "-${ndays}"
-# 	echo
-#     done
-#     echo
-# done
-
 function sequence_n_days_ahead() {
     local -i year="10#${1}"
     local -i month="10#${2}"
@@ -148,23 +112,6 @@ function sequence_n_days_ahead() {
 	local -i month_days="$(days_per_month "${year}" "${month}")"
 	for (( days_so_far=0 ; ${days_so_far} < ${ndays} ; days_so_far=${days_so_far} + 1 ));
 	do
-	    # day=$((${day} + 1))
-
-	    # if [ "${day}" -gt "${month_days}" ];
-	    # then
-	    # 	day=$((${day} - ${month_days}))
-	    # 	month=$((${month} + 1))
-
-	    # 	if [ "${month}" -gt 12 ];
-	    # 	then
-	    # 	    month=$((${month} - 12))
-	    # 	    year=$((${year} + 1))
-	    # 	fi
-
-	    # 	month_days="$(days_per_month "${year}" "${month}")"
-	    # fi
-	    # printf -v date_so_far '%04d%02d%02d ' "${year}" "${month}" "${day}"
-
 	    local -i date_so_far="$(n_days_ahead "${year}" "${month}" "${day}" 1)"
 	    printf '%08d ' "${date_so_far}"
 
@@ -175,21 +122,6 @@ function sequence_n_days_ahead() {
     else
 	for (( days_so_far=0 ; ${days_so_far} > ${ndays} ; days_so_far=${days_so_far} - 1));
 	do
-	    # day=$((${day} - 1))
-
-	    # if [ "${day}" -lt 1 ];
-	    # then
-	    # 	month=$((${month} - 1))
-
-	    # 	if [ "${month}" -lt 1 ];
-	    # 	then
-	    # 	    year=$((${year} - 1))
-	    # 	    month=$((${month} + 12))
-	    # 	fi
-	    # 	day=$((${day} + $(days_per_month "${year}" "${month}")))
-	    # fi
-	    # printf '%04d%02d%02d ' "${year}" "${month}" "${day}"
-
 	    local -i date_so_far="$(n_days_ahead "${year}" "${month}" "${day}" -1)"
 	    printf '%08d ' "${date_so_far}"
 
@@ -199,18 +131,6 @@ function sequence_n_days_ahead() {
 	done
     fi
 }
-
-# for start_date in 20210531;
-# do
-#     echo "The 32 dates starting with ${start_date}"
-#     sequence="$(sequence_n_days_ahead "${start_date:0:4}" "${start_date:4:2}" "${start_date:6:2}"  32)"
-#     echo "${sequence}: $(echo "${sequence}" | wc -w) dates"
-
-#     echo "The 32 dates before ${start_date}"
-#     sequence="$(sequence_n_days_ahead "${start_date:0:4}" "${start_date:4:2}" "${start_date:6:2}" -32)"
-#     echo "${sequence}: $(echo "${sequence}" | wc -w) dates"
-#     echo
-# done
 
 # Copy of finddate.sh
 # Prints date or date sequence a given number of days from given date
@@ -234,20 +154,5 @@ function finddate() {
     echo
 }
 
-# finddate 19990929 s+10
-# echo
-# finddate 19990929 d+10
-# echo
-# finddate 19990929 s-10
-# echo
-# finddate 19990929 d-10
-# echo
-
-# finddate 19990929 d+366
-# echo
-# finddate 19990929 d+3653
-# echo
-# finddate 19990929 d+7305
-# echo
-
+# The old finddate.sh didn't provide functions, so call the main function here
 finddate "$1" "$2"

--- a/ush/finddate.sh
+++ b/ush/finddate.sh
@@ -11,7 +11,7 @@
 #   2002, 2003, ....
 # etc.
 #
-# usage:  examples assume todays date is 19990929.
+# usage:  examples assume today's date is 19990929.
 # To generate a sequence looking 10 days forward then execute:
 #     list=`sh /nwprod/util/scripts/finddate.sh 19990929 s+10`
 # To generate just the date/time 10 days from now then execute:
@@ -28,130 +28,226 @@ set +x
 # Returns 0/true if argument is leap year
 # Returns 1/false if argument is not leap year
 function isleap() {
-    local -i year="$1"
+    local -i year="10#$1"
     local -i isleap=$((${year} % 4 == 0))
-    if [ $((${year} % 100)) -eq 0 ];
+    if [ $((${year} % 100)) -eq 0 ]
     then
-        isleap=$((${year} % 400 == 0))
+	isleap=$((${year} % 400 == 0))
     fi
     test "${isleap}" -eq 1
 }
 
+# for year in $(seq 1995 2005) $(seq 2095 2105);
+# do
+#     if isleap "${year}";
+#     then
+# 	echo "${year} is a leap year"
+#     else
+# 	echo "${year} is not a leap year"
+#     fi
+# done
+
+
 # Takes four-digit year and two-digit month as argument
-# Prints days in month to stdout
+# Prints days in that month to stdout
 function days_per_month() {
-    local -i year="$1"
+    local -i year="10#$1"
     local -i month="10#$2"
     case "${month}" in
-      1|3|5|7|8|10|12)
-          echo 31
-          ;;
-      4|6|9|11)
-          echo 30
-          ;;
-      2)
-          if isleap "${year}"
-          then
-              echo 29
-          else
-              echo 28
-          fi
-          ;;
-      *)
-          exit 1
+	1|3|5|7|8|10|12)
+	    echo 31
+	    ;;
+	4|6|9|11)
+	    echo 30
+	    ;;
+	2)
+	    if isleap "${year}"
+	    then
+		echo 29
+	    else
+		echo 28
+	    fi
+	    ;;
+	*)
+	    exit 1
     esac
 }
 
-# Takes four-digit year, two-digit month and day and days ahead as arguments
+# for year_month in $(seq 202101 202112) $(seq 199502 100 200502) 210002;
+# do
+#     echo -n "Days in ${year_month}: "
+#     days_per_month $(($year_month / 100)) $(($year_month % 100))
+# done
+
+# Takes four-digit year, month, day and days ahead as arguments
 # Prints date the given number of days after the given date in YYYYMMDD format to stdout
 function n_days_ahead() {
-    local -i year="$1"
+    local -i year="10#$1"
     local -i month="10#$2"
-    local -i day=$((10#$3 + 10#$4))
+    local -i ndays="10#$4"
+    local -i day=$((10#$3 + ${ndays}))
 
     local -i month_days="$(days_per_month "${year}" "${month}")"
     while [ "${day}" -gt "${month_days}" ];
     do
-        month=$((${month} + 1))
-        day=$((${day} - ${month_days}))
+	month=$((${month} + 1))
+	day=$((${day} - ${month_days}))
 
-        if [ "${month}" -gt 12 ];
-        then
-          year=$((${year} + 1))
-          month=$((${month} - 12))
-        fi
+	if [ "${month}" -gt 12 ];
+	then
+	    year=$((${year} + 1))
+	    month=$((${month} - 12))
+	fi
 
-        month_days="$(days_per_month "${year}" "${month}")"
+	month_days="$(days_per_month "${year}" "${month}")"
     done
 
     while [ "${day}" -lt "1" ];
     do
-      month=$((${month} - 1))
+	month=$((${month} - 1))
 
-      if [ "${month}" -lt "1" ];
-      then
-          year=$((${year} - 1))
-          month=$((${month} + 12))
-      fi
+	if [ "${month}" -lt "1" ];
+	then
+	    year=$((${year} - 1))
+	    month=$((${month} + 12))
+	fi
 
-      day=$((${day} + $(days_per_month "${year}" "${month}")))
+	day=$(( ${day} + $(days_per_month "${year}" "${month}") ))
     done
-    printf '%03d%02d%02d' "${year}" "${month}" "${day}"
+
+    printf '%04d%02d%02d' "${year}" "${month}" "${day}"
 }
 
+# for startday in 20210501 20191201;
+# do
+#     for ndays in $(seq 55 65) $(seq 85 95) 365 730;
+#     do
+# 	echo -n "${ndays} days after ${startday} is "
+# 	n_days_ahead "${startday:0:4}" "${startday:4:2}" "${startday:6:2}" "${ndays}"
+# 	echo
+#     done
+#     echo
+#
+#     for ndays in $(seq 55 65) $(seq 85 95) 365 730;
+#     do
+# 	echo -n "${ndays} days before ${startday} is "
+# 	n_days_ahead "${startday:0:4}" "${startday:4:2}" "${startday:6:2}" "-${ndays}"
+# 	echo
+#     done
+#     echo
+# done
+
 function sequence_n_days_ahead() {
-    local -i year="10#$1"
-    local -i month="10#$2"
-    local -i day="10#$3"
-    local -i ndays="10#$4"
+    local -i year="10#${1}"
+    local -i month="10#${2}"
+    local -i day="10#${3}"
+    local -i ndays="10#${4}"
 
     if [ "${ndays}" -ge 0 ];
     then
-        local -i month_days="$(days_per_month "${year}" "${month}")"
-        for (( days_so_far=0; ${days_so_far} < ${ndays} ; days_so_far=${days_so_far}+1 ));
-        do
-            local -i date_so_far="$(n_days_ahead "${year}" "${month}" "${day}" "1")"
-            printf '%08d ' "${date_so_far}"
+	local -i month_days="$(days_per_month "${year}" "${month}")"
+	for (( days_so_far=0 ; ${days_so_far} < ${ndays} ; days_so_far=${days_so_far} + 1 ));
+	do
+	    # day=$((${day} + 1))
 
-            year="${date_so_far:0:4}"
-            month="${date_so_far:4:2}"
-            day="${date_so_far:6:2}"
-        done
+	    # if [ "${day}" -gt "${month_days}" ];
+	    # then
+	    # 	day=$((${day} - ${month_days}))
+	    # 	month=$((${month} + 1))
+
+	    # 	if [ "${month}" -gt 12 ];
+	    # 	then
+	    # 	    month=$((${month} - 12))
+	    # 	    year=$((${year} + 1))
+	    # 	fi
+
+	    # 	month_days="$(days_per_month "${year}" "${month}")"
+	    # fi
+	    # printf -v date_so_far '%04d%02d%02d ' "${year}" "${month}" "${day}"
+
+	    local -i date_so_far="$(n_days_ahead "${year}" "${month}" "${day}" 1)"
+	    printf '%08d ' "${date_so_far}"
+
+	    year="10#${date_so_far:0:4}"
+	    month="10#${date_so_far:4:2}"
+	    day="10#${date_so_far:6:2}"
+	done
     else
-        for (( days_so_far=0 ; ${days_so_far} > ${ndays} ; days_so_far=${days_so_far} - 1));
-        do
-            local -i date_so_far="$(n_days_ahead "${year}" "${month}" "${day}" "-1")"
-            printf '%08d ' "${date_so_far}"
+	for (( days_so_far=0 ; ${days_so_far} > ${ndays} ; days_so_far=${days_so_far} - 1));
+	do
+	    # day=$((${day} - 1))
 
-            year="${date_so_far:0:4}"
-            month="${date_so_far:4:2}"
-            day="${date_so_far:6:2}"
-        done
+	    # if [ "${day}" -lt 1 ];
+	    # then
+	    # 	month=$((${month} - 1))
+
+	    # 	if [ "${month}" -lt 1 ];
+	    # 	then
+	    # 	    year=$((${year} - 1))
+	    # 	    month=$((${month} + 12))
+	    # 	fi
+	    # 	day=$((${day} + $(days_per_month "${year}" "${month}")))
+	    # fi
+	    # printf '%04d%02d%02d ' "${year}" "${month}" "${day}"
+
+	    local -i date_so_far="$(n_days_ahead "${year}" "${month}" "${day}" -1)"
+	    printf '%08d ' "${date_so_far}"
+
+	    year="10#${date_so_far:0:4}"
+	    month="10#${date_so_far:4:2}"
+	    day="10#${date_so_far:6:2}"
+	done
     fi
 }
 
-# The core functionality of the script, from the original finddate.sh
-# Prints date or date sequence a given number of days from given date.
-# Does not include given date in sequence.
+# for start_date in 20210531;
+# do
+#     echo "The 32 dates starting with ${start_date}"
+#     sequence="$(sequence_n_days_ahead "${start_date:0:4}" "${start_date:4:2}" "${start_date:6:2}"  32)"
+#     echo "${sequence}: $(echo "${sequence}" | wc -w) dates"
+
+#     echo "The 32 dates before ${start_date}"
+#     sequence="$(sequence_n_days_ahead "${start_date:0:4}" "${start_date:4:2}" "${start_date:6:2}" -32)"
+#     echo "${sequence}: $(echo "${sequence}" | wc -w) dates"
+#     echo
+# done
+
+# Copy of finddate.sh
+# Prints date or date sequence a given number of days from given date
 # Given date is YYYYMMDD format
 function finddate() {
-    local -i year_month_day="10#${1}"
+    local -i year_month_day="${1}"
     local -i year="10#${year_month_day:0:4}"
     local -i month="10#${year_month_day:4:2}"
     local -i day="10#${year_month_day:6:2}"
 
     local second_arg="${2}"
     local day_or_sequence="${second_arg:0:1}"
-    local -i ndays="10#${second_arg:1}"
+    local -i ndays="${second_arg:1}"
 
     if [ "${day_or_sequence}" = "d" ];
     then
-        n_days_ahead "${year}" "${month}" "${day}" "${ndays}"
+	n_days_ahead "${year}" "${month}" "${day}" "${ndays}"
     else
-        sequence_n_days_ahead "${year}" "${month}" "${day}" "${ndays}"
+	sequence_n_days_ahead "${year}" "${month}" "${day}" "${ndays}"
     fi
     echo
 }
 
-# Actually call the function, the way the old finddate.sh expects to be used
+# finddate 19990929 s+10
+# echo
+# finddate 19990929 d+10
+# echo
+# finddate 19990929 s-10
+# echo
+# finddate 19990929 d-10
+# echo
+
+# finddate 19990929 d+366
+# echo
+# finddate 19990929 d+3653
+# echo
+# finddate 19990929 d+7305
+# echo
+
 finddate "$1" "$2"

--- a/ush/test_finddate.sh
+++ b/ush/test_finddate.sh
@@ -3,6 +3,18 @@
 echo TAP version 14
 
 declare -i test_num=1
+declare -i suite_status=0
+function tap_start() {
+    declare -i num_tests="$1"
+    echo "1..${num_tests}"
+    test_num=1
+    suite_status=0
+}
+function tap_end() {
+    echo "Result: ${suite_status} failures"
+    exit ${suite_status}
+}
+
 function tap_log_test() {
     local -i status="$1"
     local message="$2"
@@ -14,6 +26,7 @@ function tap_log_test() {
 
     echo "ok ${test_num} - ${message}"
     test_num=$((${test_num} + 1))
+    suite_status=$((${suite_status} + ${status}))
 }
 
 declare -i subtest_num=1
@@ -53,11 +66,12 @@ function tap_end_subtest() {
 
     echo "ok ${test_num} - ${name}"
     test_num=$((${test_num} + 1))
+    suite_status=$((${suite_status} + ${status}))
 }
 
 ############################################################
 
-echo 1..5
+echo 1..6
 
 # Comment out the output from loading the test functions
 echo -n '# '
@@ -163,3 +177,81 @@ do
     done
 done
 tap_end_subtest sequence_n_days_ahead
+
+tap_start_subtest "finddate matches old output" 4
+start_date=19990929
+
+declare +i actual="$(finddate "${start_date}" s+10)"
+declare +i expected="19990930 19991001 19991002 19991003 19991004 19991005 19991006 19991007 19991008 19991009 "
+if [ "${actual}" = "${expected}" ];
+then
+    result=0
+else
+    result=1
+fi
+tap_log_subtest "${result}" "s+10 matches old output"
+
+actual="$(finddate "${start_date}" d+10)"
+expected="19991009"
+if [ "${actual}" = "${expected}" ];
+then
+    result=0
+else
+    result=1
+fi
+tap_log_subtest "${result}" "d+10 matches old output"
+
+actual="$(finddate "${start_date}" s-10)"
+expected="19990928 19990927 19990926 19990925 19990924 19990923 19990922 19990921 19990920 19990919 "
+if [ "${actual}" = "${expected}" ];
+then
+    result=0
+else
+    result=1
+fi
+tap_log_subtest "${result}" "s-10 matches old output"
+
+actual="$(finddate "${start_date}" d-10)"
+expected="19990919"
+if [ "${actual}" = "${expected}" ];
+then
+    result=0
+else
+    result=1
+fi
+tap_log_subtest "${result}" "d-10 matches old output"
+tap_end_subtest "finddate matches old output"
+
+tap_start_subtest "finddate extreme examples" 3
+declare -i actual="10#$(finddate "${start_date}" d+366)"
+declare -i expected="20000929"
+if [ "${actual}" -eq "${expected}" ];
+then
+    result=0
+else
+    result=1
+fi
+tap_log_subtest "${result}" "One-year ahead match: expected ${expected} got ${actual}"
+
+actual="10#$(finddate "${start_date}" d+3653)"
+expected="20090929"
+if [ "${actual}" -eq "${expected}" ];
+then
+    result=0
+else
+    result=1
+fi
+tap_log_subtest "${result}" "Ten-year ahead match: expected ${expected} got ${actual}"
+
+actual="10#$(finddate "${start_date}" d+7305)"
+expected="20190929"
+if [ "${actual}" -eq "${expected}" ];
+then
+    result=0
+else
+    result=1
+fi
+tap_log_subtest "${result}" "Twenty-year ahead match: expected ${expected} got ${actual}"
+tap_end_subtest "finddate extreme examples"
+
+tap_end

--- a/ush/test_finddate.sh
+++ b/ush/test_finddate.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+echo TAP version 14
+
+declare -i test_num=1
+function tap_log_test() {
+    local -i status="$1"
+    local message="$2"
+
+    if [ "${status}" -ne 0 ]
+    then
+	echo -n 'not '
+    fi
+
+    echo "ok ${test_num} - ${message}"
+    test_num=$((${test_num} + 1))
+}
+
+declare -i subtest_num=1
+declare -i subtest_suite_result=0
+function tap_log_subtest() {
+    local -i status="$1"
+    local message="$2"
+    echo -n '    '
+
+    if [ "${status}" -ne 0 ]
+    then
+	echo -n 'not '
+	subtest_suite_result=$((${subtest_suite_result} + ${status}))
+    fi
+
+    echo "ok ${subtest_num} - ${message}"
+    subtest_num=$((${subtest_num} + 1))
+}
+
+function tap_start_subtest() {
+    local name="${1}"
+    local -i ntests="${2}"
+    echo "# Subtest: ${name}"
+    echo "    1..${ntests}"
+    subtest_num=1
+    subtest_suite_result=0
+}
+
+function tap_end_subtest() {
+    local name="${1}"
+    local -i status="${subtest_suite_result}"
+    
+    if [ "${status}" -ne 0 ];
+    then
+	echo -n 'not '
+    fi
+
+    echo "ok ${test_num} - ${name}"
+    test_num=$((${test_num} + 1))
+}
+
+############################################################
+
+echo 1..5
+
+# Comment out the output from loading the test functions
+echo -n '# '
+. test_find_date.sh 19990929 d+10
+
+tap_start_subtest isleap 22
+for year in $(seq 1995 2005) $(seq 2095 2105);
+do
+    if echo 1996 2000 2004 2096 2104 | grep --quiet -F -e ${year} -;
+    then
+	expected=0
+    else
+	expected=1
+    fi
+
+    if isleap "${year}";
+    then
+	actual=0
+    else
+	actual=1
+    fi
+
+    if [ "${expected}" -eq "${actual}" ];
+    then
+	result=0
+    else
+	result=1
+    fi
+
+    tap_log_subtest "${result}" "Year ${year}"
+done
+tap_end_subtest isleap
+
+tap_start_subtest days_per_month 24
+
+for year_month_days in 20210131 20210228 20210331 20210430 20210531 \
+    20210630 20210731 20210831 20210930 20211031 20211130 20211231 \
+    19950228 19960229 19990228 20000229 20010228 20040229 21000228;
+do
+    declare -i year="${year_month_days:0:4}"
+    declare -i month="10#${year_month_days:4:2}"
+    declare -i ndays="10#${year_month_days:6:2}"
+    declare -i month_days="10#$(days_per_month "${year}" "${month}")"
+    if [ "${month_days}" -eq "${ndays}" ];
+    then
+	result=0
+    else
+	result=1
+    fi
+    tap_log_subtest "${result}" "${year}-${month} expected ${ndays} got ${month_days}"
+done
+
+tap_end_subtest days_per_month
+
+tap_start_subtest n_days_ahead 6
+start_date=19990929
+for days_year in 03662000 -3651998 07312001 -7301997 36532009 73052019;
+do
+    declare -i ndays="10#${days_year:0:4}"
+    declare -i expected="10#${days_year:4}0929"
+    actual="$(n_days_ahead "${start_date:0:4}" "${start_date:4:2}" "${start_date:6:2}" "${ndays}")"
+
+    if [ "${actual}" -eq "${expected}" ];
+    then
+	result=0
+    else
+	result=1
+    fi
+    tap_log_subtest "${result}" \
+	"${ndays} days from ${start_date}: exptected ${expected} got ${actual}"
+done
+tap_end_subtest n_days_ahead
+
+tap_start_subtest sequence_n_days_ahead 24
+declare -i start_date=19990929
+declare -i start_year="10#${start_date:0:4}"
+declare -i start_month="10#${start_date:4:2}"
+declare -i start_day="10#${start_date:6:2}"
+for sign in '' '-';
+do
+    for ndays in $(seq 1 2 10) 400;
+    do
+	actual="$(sequence_n_days_ahead "${start_year}" "${start_month}" "${start_day}" "${sign}${ndays}")"
+	nwords="$(echo "${actual}" | wc -w)"
+	if [ "${nwords}" -eq "${ndays}" ];
+	then
+	    result=0
+	else
+	    result=1
+	fi
+	tap_log_subtest "${result}" "Sequence length: ${sign}${ndays}"
+
+	actual_last_date="$(echo "${actual}" | awk '{ print $NF; }')"
+	expected_last_date="$(n_days_ahead "${start_year}" "${start_month}" "${start_day}" "${sign}${ndays}")"
+	if [ "${actual_last_date}" = "${expected_last_date}" ];
+	then
+	    result=0
+	else
+	    result=1
+	fi
+	tap_log_subtest "${result}" \
+	    "Last date in sequence: expected ${expected_last_date} actual ${actual_last_date}"
+    done
+done
+tap_end_subtest sequence_n_days_ahead


### PR DESCRIPTION
The old code handled one month boundary, so it could add sixty days to 2021-05-01 to get 2021-06-30, but adding 62 days would produce 2021-06-32.  These changes allow the script to work when requesting dates twenty years ahead or behind the given date.

I also updated the leap-year calculation from Julian to Gregorian, which will annoy people running forecasts pre-1500 and help people running forecasts in 1900 or 2100.

I added some tests to be sure this was working, including one to ensure the output is the same as the old version.  My version has a trailing space at the end of all sequences of dates, but that looks the same as the old version.
