### PR TITLE
Updates for ocean ice interpolation utility.

### DIFF
--- a/parm/ocnicepost/ocnicepost.nml.jinja2
+++ b/parm/ocnicepost/ocnicepost.nml.jinja2
@@ -1,6 +1,6 @@
 & ocnicepost_nml
   ftype = "{{ component }}",
-  wgtsdir = "{{ interpolation_weights_dir }}/",
+  wgtsdir = "./",
   srcdims = {{ source_tripole_dims }},
   dstdims = {{ target_latlon_dims }},
   maskvar = "{{ maskvar }}",

--- a/parm/ocnicepost/ocnicepost.nml.jinja2
+++ b/parm/ocnicepost/ocnicepost.nml.jinja2
@@ -1,11 +1,11 @@
 & ocnicepost_nml
-  ftype = {{ component }},
-  wgtsdir = {{ interpolation_weights_dir }},
+  ftype = "{{ component }}",
+  wgtsdir = "{{ interpolation_weights_dir }}/",
   srcdims = {{ source_tripole_dims }},
   dstdims = {{ target_latlon_dims }},
-  maskvar = {{ maskvar }},
-  sinvar = {{ sinvar }},
-  cosvar = {{ cosvar }},
-  angvar = {{ angvar }},
+  maskvar = "{{ maskvar }}",
+  sinvar = "{{ sinvar }}",
+  cosvar = "{{ cosvar }}",
+  angvar = "{{ angvar }}",
   debug = {{ debug | default('.false.') }}
 /

--- a/src/ocnicepost.fd/init_mod.F90
+++ b/src/ocnicepost.fd/init_mod.F90
@@ -104,9 +104,9 @@ contains
 
     fdst = ''
     if (nxr == 1440 .and. nyr == 721) fdst = '0p25'      ! 1/4deg rectilinear
-    if (nxr == 720  .and. nyr == 361) fdst = '0p5'       ! 1/2 deg rectilinear
-    if (nxr == 360  .and. nyr == 181) fdst = '1p0'       ! 1 deg rectilinear
-    if (nxr == 72   .and. nyr == 36) fdst = '5p0'        ! 5 deg rectilinear
+    if (nxr == 720  .and. nyr == 361) fdst = '0p50'      ! 1/2 deg rectilinear
+    if (nxr == 360  .and. nyr == 181) fdst = '1p00'      ! 1 deg rectilinear
+    if (nxr == 72   .and. nyr == 36) fdst = '5p00'       ! 5 deg rectilinear
     if (len_trim(fdst) == 0) then
        write(logunit,'(a)')'destination grid dimensions unknown'
        stop

--- a/src/ocnicepost.fd/init_mod.F90
+++ b/src/ocnicepost.fd/init_mod.F90
@@ -50,7 +50,7 @@ contains
     ! local variable
     character(len=40) :: fname
     integer :: ierr, iounit
-    integer :: srcdims(3), dstdims(2)
+    integer :: srcdims(2), dstdims(2)
 
     namelist /ocnicepost_nml/ ftype, srcdims, wgtsdir, dstdims, maskvar, sinvar, cosvar, &
          angvar, debug
@@ -78,12 +78,11 @@ contains
     close (iounit)
     nxt = srcdims(1); nyt = srcdims(2)
     nxr = dstdims(1); nyr = dstdims(2)
-    If (srcdims(3) > 0) nlevs = srcdims(3)
 
     ! initialize the source file type and variables
     if (trim(ftype) == 'ocean') then
        do_ocnpost = .true.
-       else
+    else
        do_ocnpost = .false.
     end if
     input_file = trim(ftype)//'.nc'

--- a/src/ocnicepost.fd/init_mod.F90
+++ b/src/ocnicepost.fd/init_mod.F90
@@ -7,13 +7,13 @@ module init_mod
   real, parameter :: maxvars = 50              !< The maximum number of fields expected in a source file
 
   type :: vardefs
-     character(len= 10)   :: var_name          !< A variable's variable name
+     character(len= 20)   :: var_name          !< A variable's variable name
      character(len=120)   :: long_name         !< A variable's long name
      character(len= 20)   :: units             !< A variable's unit
-     character(len= 10)   :: var_remapmethod   !< A variable's mapping method
+     character(len= 20)   :: var_remapmethod   !< A variable's mapping method
      integer              :: var_dimen         !< A variable's dimensionality
      character(len=  4)   :: var_grid          !< A variable's input grid location; all output locations are on cell centers
-     character(len= 10)   :: var_pair          !< A variable's pair
+     character(len= 20)   :: var_pair          !< A variable's pair
      character(len=  4)   :: var_pair_grid     !< A pair variable grid
      real                 :: var_fillvalue     !< A variable's fillvalue
   end type vardefs
@@ -120,7 +120,7 @@ contains
 
     character(len= 40) :: fname
     character(len=100) :: chead
-    character(len= 10) :: c1,c3,c4,c5,c6
+    character(len= 20) :: c1,c3,c4,c5,c6
     integer :: i2
     integer :: nn,n,ierr,iounit
 

--- a/src/ocnicepost.fd/ocnicepost.F90
+++ b/src/ocnicepost.fd/ocnicepost.F90
@@ -79,6 +79,11 @@ program ocnicepost
     call nf90_err(nf90_inquire_dimension(ncid, varid, len=nlevs), 'get dimension Id: z_l'//trim(input_file))
   endif
   do n = 1,nvalid
+     if (debug) then
+        write(logunit,'(a12,i4,a10,3(a6))')trim(outvars(n)%var_name)//', ',outvars(n)%var_dimen, &
+           ', '//trim(outvars(n)%var_remapmethod),', '//trim(outvars(n)%var_grid),             &
+           ', '//trim(outvars(n)%var_pair),', '//trim(outvars(n)%var_pair_grid)
+     end if
      call nf90_err(nf90_inq_varid(ncid, trim(outvars(n)%var_name), varid), 'get variable Id: '//trim(outvars(n)%var_name))
      call nf90_err(nf90_get_att(ncid, varid,  'long_name', outvars(n)%long_name), 'get variable attribute: long_name '//trim(outvars(n)%var_name))
      call nf90_err(nf90_get_att(ncid, varid,      'units', outvars(n)%units), 'get variable attribute: units '//trim(outvars(n)%var_name)        )
@@ -111,14 +116,6 @@ program ocnicepost
      call getfield(trim(input_file), trim(angvar), dims=(/nxt,nyt/), field=anglet)
      cosrot =  cos(anglet)
      sinrot = -sin(anglet)
-  end if
-
-  if (debug) then
-     do n = 1,nvalid
-        write(logunit,'(a12,i4,a10,3(a6))')trim(outvars(n)%var_name)//', ',outvars(n)%var_dimen, &
-             ', '//trim(outvars(n)%var_remapmethod),', '//trim(outvars(n)%var_grid),             &
-             ', '//trim(outvars(n)%var_pair),', '//trim(outvars(n)%var_pair_grid)
-     end do
   end if
 
   ! --------------------------------------------------------

--- a/src/ocnicepost.fd/ocnicepost.F90
+++ b/src/ocnicepost.fd/ocnicepost.F90
@@ -74,6 +74,10 @@ program ocnicepost
   ! --------------------------------------------------------
 
   call nf90_err(nf90_open(trim(input_file), nf90_nowrite, ncid), 'open: '//trim(input_file))
+  if (do_ocnpost) then
+    call nf90_err(nf90_inq_dimid(ncid, 'z_l', varid), 'get dimension Id: z_l'//trim(input_file))
+    call nf90_err(nf90_inquire_dimension(ncid, varid, len=nlevs), 'get dimension Id: z_l'//trim(input_file))
+  endif
   do n = 1,nvalid
      call nf90_err(nf90_inq_varid(ncid, trim(outvars(n)%var_name), varid), 'get variable Id: '//trim(outvars(n)%var_name))
      call nf90_err(nf90_get_att(ncid, varid,  'long_name', outvars(n)%long_name), 'get variable attribute: long_name '//trim(outvars(n)%var_name))

--- a/src/ocnicepost.fd/utils_mod.F90
+++ b/src/ocnicepost.fd/utils_mod.F90
@@ -1,7 +1,7 @@
 module utils_mod
 
   use netcdf
-  use init_mod, only : debug, logunit, vardefs
+  use init_mod, only : debug, logunit, vardefs, fsrc
 
   implicit none
 
@@ -164,10 +164,10 @@ contains
 
     if (debug)write(logunit,'(a)')'enter '//trim(subname)
 
-    wgtsfile = trim(wdir)//'tripole.mx025.'//vgrid1//'.to.Ct.bilinear.nc'
+    wgtsfile = trim(wdir)//'tripole.'//trim(fsrc)//'.'//vgrid1//'.to.Ct.bilinear.nc'
     call getfield(fname, vname1, dims=dims, field=vecpair(:,1), wgts=trim(wgtsfile))
     if (debug)write(logunit,'(a)')'wgtsfile for 2d vector '//trim(vname1)//'   '//trim(wgtsfile)
-    wgtsfile = trim(wdir)//'tripole.mx025.'//vgrid2//'.to.Ct.bilinear.nc'
+    wgtsfile = trim(wdir)//'tripole.'//trim(fsrc)//'.'//vgrid2//'.to.Ct.bilinear.nc'
     call getfield(fname, vname2, dims=dims, field=vecpair(:,2), wgts=trim(wgtsfile))
     if (debug)write(logunit,'(a)')'wgtsfile for 2d vector '//trim(vname2)//'   '//trim(wgtsfile)
 
@@ -203,9 +203,9 @@ contains
 
     if (debug)write(logunit,'(a)')'enter '//trim(subname)
 
-    wgtsfile = trim(wdir)//'tripole.mx025.'//vgrid1//'.to.Ct.bilinear.nc'
+    wgtsfile = trim(wdir)//'tripole.'//trim(fsrc)//'.'//vgrid1//'.to.Ct.bilinear.nc'
     call getfield(fname, vname1, dims=dims, field=vecpair(:,:,1), wgts=trim(wgtsfile))
-    wgtsfile = trim(wdir)//'tripole.mx025.'//vgrid2//'.to.Ct.bilinear.nc'
+    wgtsfile = trim(wdir)//'tripole.'//trim(fsrc)//'.'//vgrid2//'.to.Ct.bilinear.nc'
     call getfield(fname, vname2, dims=dims, field=vecpair(:,:,2), wgts=trim(wgtsfile))
 
     do k = 1,dims(3)


### PR DESCRIPTION
This PR:
- updates the template for the namelist
- infers the vertical levels for `srcdims` from the input file when processing ocean data.  ice does not have levels.
- fixes a bug that allows interpolating from any model grid other than `mx025`.