### PR TITLE
Remove SENDCOM from make_ntc_bull

### DIFF
--- a/ush/make_ntc_bull.pl
+++ b/ush/make_ntc_bull.pl
@@ -26,7 +26,6 @@
 #------------------------------------------------------
 
 if ($ENV{job}) { $job=$ENV{job}; }
-if ($ENV{SENDCOM}) { $SENDCOM=$ENV{SENDCOM}; }
 if ($ENV{SENDDBN}) { $SENDDBN=$ENV{SENDDBN}; }
 $NArgs = @ARGV;
 
@@ -112,14 +111,12 @@ sub make_tocbull {
       $ByteCount = length($cho2);
       print " length is $ByteCount ";
       $BulletinFlagFieldSep = sprintf( "****%10.10d****", $ByteCount);
-      if ($SENDCOM eq "YES") {
-        if ($ByteCount  >  50  ) {
-          print OUTFILE "$BulletinFlagFieldSep\n";
-          print OUTFILE $cho2;
-        }
-        else {   
-          $ix = 1;
-        }
+      if ($ByteCount  >  50  ) {
+        print OUTFILE "$BulletinFlagFieldSep\n";
+        print OUTFILE $cho2;
+      }
+      else {
+        $ix = 1;
       }
    }
    close OUTFILE;
@@ -169,14 +166,12 @@ sub make_tocplot {
       $ByteCount = length($cho2);
       print " length is $ByteCount ";
       $BulletinFlagFieldSep = sprintf( "****%10.10d****", $ByteCount);
-      if ($SENDCOM eq "YES") {
-        if ($ByteCount  >  50  ) {
-          print OUTFILE "$BulletinFlagFieldSep\n";
-          print OUTFILE $cho2;
-        }
-        else {
-          $ix = 1;
-        }
+      if ($ByteCount  >  50  ) {
+        print OUTFILE "$BulletinFlagFieldSep\n";
+        print OUTFILE $cho2;
+      }
+      else {
+        $ix = 1;
       }
    }
    close OUTFILE;
@@ -221,12 +216,9 @@ sub make_tocredb {
    $ByteCount = length($cho);
    print " length is $ByteCount ";
    $BulletinFlagFieldSep = sprintf( "****%10.10d****", $ByteCount);
-   if ($SENDCOM eq "YES") {
-      if ($ByteCount  >  50  ) {
-          print OUTFILE "$BulletinFlagFieldSep\n";
-          print OUTFILE $cho;
-          
-      }
+   if ($ByteCount  >  50  ) {
+     print OUTFILE "$BulletinFlagFieldSep\n";
+     print OUTFILE $cho;
    }
    close OUTFILE;
    if ($SENDDBN eq "YES" ) {


### PR DESCRIPTION
# Description
The use of SENDCOM was retired in global workflow. make_ntc_bull is updated to match.

Refs NOAA-EMC/global-workflow#2479

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Part of global-workflow on WCOSS

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
