### PR TITLE
Change GRIB2 parameter names and vertical levels for nc2grb

### DIFF
--- a/ush/nc2grb/nc2grb.ice.sh
+++ b/ush/nc2grb/nc2grb.ice.sh
@@ -9,6 +9,7 @@ set -x
 # input netCDF file has a different resolution, use wgrib2 to regrid
 # the template file.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov), 11/02/2023
+#         updated on 05/20/2024
 
 module load intel/19.1.3.304
 module load wgrib2/2.0.8
@@ -47,23 +48,23 @@ wgrib2 template.global.0p25.gb2 \
 # tables in wgrib2 v2.0.8:
 #
 #  -import_netcdf $infile "hs_h" "0:1:0:721:0:1440" \
-#    -set_var ??? -set center 7 \
+#    -set_var SNVOLSI -set center 7 \
 #    -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
 #    -set_scaling same same -set_grib_type c1 -grib_out $outfile \ 
 #  -import_netcdf $infile "frzmlt_h" "0:1:0:721:0:1440" \
-#    -set_var ??? -set center 7 \
+#    -set_var FRZMLTPOT -set center 7 \
 #    -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
 #    -set_scaling same same -set_grib_type c1 -grib_out $outfile \
 #  -import_netcdf $infile "albsni_h" "0:1:0:721:0:1440" \
-#    -set_var ALBICE -set center 7 -rpn "100.0:/" \
+#    -set_var ALBDOICE -set center 7 -rpn "100.0:/" \
 #    -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
 #    -set_scaling same same -set_grib_type c1 -grib_out $outfile \
 #  -import_netcdf $infile "mlt_onset_h" "0:1:0:721:0:1440" \
-#    -set_var ??? -set center 7 \
+#    -set_var MLTDATE -set center 7 \
 #    -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
 #    -set_scaling same same -set_grib_type c1 -grib_out $outfile \
 #  -import_netcdf $infile "frz_onset_h" "0:1:0:721:0:1440" \
-#    -set_var ??? -set center 7 \
+#    -set_var FRZDATE -set center 7 \
 #    -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
 #    -set_scaling same same -set_grib_type c1 -grib_out $outfile \
 

--- a/ush/nc2grb/nc2grb.ocean_2D.sh
+++ b/ush/nc2grb/nc2grb.ocean_2D.sh
@@ -9,6 +9,7 @@ set -x
 # input netCDF file has a different resolution, use wgrib2 to regrid
 # the template file.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov), 11/02/2023
+#         updated on 05/20/2024
 
 module load intel/19.1.3.304
 module load wgrib2/2.0.8
@@ -30,7 +31,7 @@ wgrib2 template.global.0p25.gb2 \
     -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
     -set_scaling same same -set_grib_type c1 -grib_out $outfile \
   -import_netcdf $infile "SSS" "0:1:0:721:0:1440" \
-    -set_var SALTY -set center 7 -rpn "1000.0:/" \
+    -set_var SALIN -set center 7 \
     -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
     -set_scaling same same -set_grib_type c1 -grib_out $outfile \
   -import_netcdf $infile "speed" "0:1:0:721:0:1440" \
@@ -54,11 +55,11 @@ wgrib2 template.global.0p25.gb2 \
     -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
     -set_scaling same same -set_grib_type c1 -grib_out $outfile \
   -import_netcdf $infile "SW" "0:1:0:721:0:1440" \
-    -set_var DSWRF -set center 7 \
+    -set_var NSWRF -set center 7 \
     -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
     -set_scaling same same -set_grib_type c1 -grib_out $outfile \
   -import_netcdf $infile "LW" "0:1:0:721:0:1440" \
-    -set_var DLWRF -set center 7 \
+    -set_var NLWRF -set center 7 \
     -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
     -set_scaling same same -set_grib_type c1 -grib_out $outfile \
   -import_netcdf $infile "LwLatSens" "0:1:0:721:0:1440" \

--- a/ush/nc2grb/nc2grb.ocean_3D.sh
+++ b/ush/nc2grb/nc2grb.ocean_3D.sh
@@ -9,6 +9,7 @@ set -x
 # input netCDF file has a different resolution, use wgrib2 to regrid
 # the template file.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov), 11/02/2023
+#         updated on 05/20/2024
 
 module load intel/19.1.3.304
 module load wgrib2/2.0.8
@@ -19,7 +20,7 @@ infile=ocean.0p25.nc
 outfile=ocean_3D.0p25.gb2
 ddate=2013100100
 aperiod="0-6"
-levlst="5 15 25 35 45 55 65 75 85 95 105 115 125 135 145 155 165 175 185 195 205 215 225.86945 241.06255 266.5239 308.7874 373.9288 467.3998 593.87915 757.1453 959.97325 1204.059 1489.9735 1817.1455 2183.879 2587.3995 3023.9285 3488.7875 3976.524 4481.0625"
+levlst="5 15 25 35 45 55 65 75 85 95 105 115 125 135 145 155 165 175 185 195 205 215 226 241 267 309 374 467 594 757 960 1204 1490 1817 2184 2587 3024 3489 3977 4481"
 
 zl=0
 for depth in $levlst; do
@@ -27,22 +28,22 @@ for depth in $levlst; do
 wgrib2 template.global.0p25.gb2 \
   -import_netcdf $infile "temp" "0:1:$zl:1:0:721:0:1440" \
     -set_var WTMP -set center 7 -rpn "273.15:+" \
-    -set_lev "$depth m below water surface" \
+    -set_lev "$depth m below sea level" \
     -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
     -set_scaling same same -set_grib_type c1 -grib_out tmp.gb2 \
   -import_netcdf $infile "so" "0:1:$zl:1:0:721:0:1440" \
-    -set_var SALTY -set center 7 -rpn "1000.0:/" \
-    -set_lev "$depth m below water surface" \
+    -set_var SALIN -set center 7 \
+    -set_lev "$depth m below sea level" \
     -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
     -set_scaling same same -set_grib_type c1 -grib_out tmp.gb2 \
   -import_netcdf $infile "uo" "0:1:$zl:1:0:721:0:1440" \
     -set_var UOGRD -set center 7 \
-    -set_lev "$depth m below water surface" \
+    -set_lev "$depth m below sea level" \
     -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
     -set_scaling same same -set_grib_type c1 -grib_out tmp.gb2 \
   -import_netcdf $infile "vo" "0:1:$zl:1:0:721:0:1440" \
     -set_var VOGRD -set center 7 \
-    -set_lev "$depth m below water surface" \
+    -set_lev "$depth m below sea level" \
     -set_date $ddate -set_ftime "$aperiod hour ave fcst" \
     -set_scaling same same -set_grib_type c1 -grib_out tmp.gb2
 


### PR DESCRIPTION
# Description
Based on users' feedback, this PR do the following:

1. Change GRIB2 parameter names DLWRF -> NLWRF and DSWRF -> NSWRF
2. Change the vertical level of ocean 3D variables (WTMP, SALIN, UOGRD, and VOGRD) from "%g m below water surface" to "%g m below sea level"
3. Round up depth numbers to integer (e.g. 4481.0625 -> 4481 m)

# Type of change
- Update

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Tested on WCOSS2 using sample netcdf files and successfully generated grib2 files.

# Checklist
- [X] Any dependent changes have been merged and published
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary