### PR TITLE
Use contrib installation of spack-stack on Jet

### DIFF
--- a/modulefiles/gfsutils_jet.intel.lua
+++ b/modulefiles/gfsutils_jet.intel.lua
@@ -2,7 +2,7 @@ help([[
 Build environment for GFS utilities on Jet
 ]])
 
-prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-intel/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"


### PR DESCRIPTION
# Description
- Update Jet module file to use /contrib installation of spack-stack;
- Following the failure of the lfs4 storage, spack stack was moved to /contrib and present module file no longer works

  Resolves #78 
  Refs NOAA-EMC/global-workflow#2841


# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Clone and build on Jet
- Cycle test with Global Workflow at the following resolutions on Jet:
  - [x] 96/48 on kjet
  - [x] 192/96 on kjet
  - [x] 384/192 on kjet

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
