### PR TITLE
Upgrade to spack-stack 1.8.0 and restructure module files

### DIFF
--- a/modulefiles/gfsutils_common.lua
+++ b/modulefiles/gfsutils_common.lua
@@ -5,19 +5,19 @@ Load common modules to build GFS utilities on all machines
 local netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
 local netcdf_fortran_ver=os.getenv("netcdf_fortran_ver") or "4.6.1"
 
-local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
+local bufr_ver=os.getenv("bufr_ver") or "12.0.1"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
 local sp_ver=os.getenv("sp_ver") or "2.5.0"
-local ip_ver=os.getenv("ip_ver") or "4.3.0"
+local ip_ver=os.getenv("ip_ver") or "5.0.0"
 local sigio_ver=os.getenv("sigio_ver") or "2.3.2"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local nemsiogfs_ver=os.getenv("nemsiogfs_ver") or "2.5.3"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
-local g2_ver=os.getenv("g2_ver") or "3.4.5"
+local g2_ver=os.getenv("g2_ver") or "3.4.9"
 local landsfcutil_ver=os.getenv("landsfcutil_ver") or "2.4.1"
-local wgrib2_ver=os.getenv("wgrib2_ver") or "2.0.8"
+local wgrib2_ver=os.getenv("wgrib2_ver") or "3.1.1"
 local libpng_ver=os.getenv("libpng_ver") or "1.6.37"
 
 load(pathJoin("libpng", libpng_ver))

--- a/modulefiles/gfsutils_common.lua
+++ b/modulefiles/gfsutils_common.lua
@@ -2,10 +2,12 @@ help([[
 Load common modules to build GFS utilities on all machines
 ]])
 
+local stack_ver=os.getenv("stack_ver") or "1.8.0"
+local stack_env_path=os.getenv("stack_env_path") or pathJoin(stack_root, "spack-stack-" .. stack_ver, "/envs")
+local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 local netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
 local netcdf_fortran_ver=os.getenv("netcdf_fortran_ver") or "4.6.1"
-
-local bufr_ver=os.getenv("bufr_ver") or "12.0.1"
+local bufr_ver=os.getenv("bufr_ver") or "12.1.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
 local sp_ver=os.getenv("sp_ver") or "2.5.0"
@@ -15,11 +17,17 @@ local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local nemsiogfs_ver=os.getenv("nemsiogfs_ver") or "2.5.3"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
-local g2_ver=os.getenv("g2_ver") or "3.4.9"
+local g2_ver=os.getenv("g2_ver") or "3.5.1"
 local landsfcutil_ver=os.getenv("landsfcutil_ver") or "2.4.1"
 local wgrib2_ver=os.getenv("wgrib2_ver") or "3.1.1"
 local libpng_ver=os.getenv("libpng_ver") or "1.6.37"
 
+prepend_path("MODULEPATH", pathJoin(stack_env_path, stack_env, 'install/modulefiles/Core'))
+
+load(stack_compiler)
+load(stack_mpi)
+
+load(pathJoin("cmake", cmake_ver))
 load(pathJoin("libpng", libpng_ver))
 
 load(pathJoin("netcdf-c", netcdf_c_ver))

--- a/modulefiles/gfsutils_gaea.intel.lua
+++ b/modulefiles/gfsutils_gaea.intel.lua
@@ -5,23 +5,19 @@ help([[
 
 whatis([===[Loads libraries needed for building the UFS Weather Model on Gaea ]===])
 
-prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
-prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
-
+--Compiler and MPI versions
 stack_intel_ver=os.getenv("stack_intel_ver") or "2023.1.0"
-load(pathJoin("stack-intel", stack_intel_ver))
-
 stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.25"
-load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
 
-stack_python_ver=os.getenv("stack_python_ver") or "3.11.6"
-load(pathJoin("stack-python", stack_python_ver))
+--Spack-stack root path and environment name
+stack_root=os.getenv("stack_root") or "/usw/spack-stack/c5"
+stack_env=os.getenv(stack_env) or "ue-intel-" .. stack_intel_ver
 
-cmake_ver=os.getenv("cmake_ver") or "3.23.1"
-load(pathJoin("cmake", cmake_ver))
+--Stack compiler and MPI modules to load
+stack_compiler=os.getenv("stack_compiler") or pathJoin("stack-intel", stack_intel_ver)
+stack_mpi=os.getenv("stack_mpi") or pathJoin("stack-cray-mpich", stack_cray_mpich_ver)
 
 load("gfsutils_common")
-load("nccmp/1.9.0.1")
 
 unload("darshan-runtime")
 unload("cray-libsci")

--- a/modulefiles/gfsutils_hera.intel.lua
+++ b/modulefiles/gfsutils_hera.intel.lua
@@ -2,15 +2,17 @@ help([[
 Build environment for GFS utilities on Hera
 ]])
 
-prepend_path("MODULEPATH", '/scratch1/NCEPDEV/global/David.Huber/SPACK/ss_1.8.0/envs/gsi-addon/install/modulefiles/Core')
+--Compiler and MPI versions
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
-local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+--Spack-stack root path and environment name
+stack_root=os.getenv("stack_root") or "/contrib/spack-stack"
+stack_env=os.getenv("stack_env") or "ue-intel-" .. stack_intel_ver
 
-load(pathJoin("stack-intel", stack_intel_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-load(pathJoin("cmake", cmake_ver))
+--Stack compiler and MPI modules to load
+stack_compiler=os.getenv("stack_compiler") or pathJoin("stack-intel", stack_intel_ver)
+stack_mpi=os.getenv("stack_mpi") or pathJoin("stack-intel-oneapi-mpi", stack_impi_ver)
 
 load("gfsutils_common")
 

--- a/modulefiles/gfsutils_hera.intel.lua
+++ b/modulefiles/gfsutils_hera.intel.lua
@@ -2,7 +2,7 @@ help([[
 Build environment for GFS utilities on Hera
 ]])
 
-prepend_path("MODULEPATH", '/scratch1/NCEPDEV/nems/Alexander.Richert/spack-stack-py311-aug24/envs/test/install/modulefiles/Core')
+prepend_path("MODULEPATH", '/scratch1/NCEPDEV/global/David.Huber/SPACK/ss_1.8.0/envs/gsi-addon/install/modulefiles/Core')
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"

--- a/modulefiles/gfsutils_hera.intel.lua
+++ b/modulefiles/gfsutils_hera.intel.lua
@@ -2,11 +2,11 @@ help([[
 Build environment for GFS utilities on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", '/scratch1/NCEPDEV/nems/Alexander.Richert/spack-stack-py311-aug24/envs/test/install/modulefiles/Core')
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
-local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))

--- a/modulefiles/gfsutils_hercules.intel.lua
+++ b/modulefiles/gfsutils_hercules.intel.lua
@@ -2,14 +2,17 @@ help([[
 Build environment for GFS utilities on Hercules
 ]])
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+--Compiler and MPI versions
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.9.0"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.9.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"
-local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+--Spack-stack root path and environment name
+stack_root=os.getenv("stack_root") or "/work/noaa/role-epic/spack-stack/hercules"
+stack_env=os.getenv("stack_env") or "ue-intel-" .. stack_intel_ver
 
-load(pathJoin("stack-intel", stack_intel_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+--Stack compiler and MPI modules to load
+stack_compiler=os.getenv("stack_compiler") or pathJoin("stack-intel", stack_intel_ver)
+stack_mpi=os.getenv("stack_mpi") or pathJoin("stack-intel-oneapi-mpi", stack_impi_ver)
 
 load(pathJoin("cmake", cmake_ver))
 

--- a/modulefiles/gfsutils_jet.intel.lua
+++ b/modulefiles/gfsutils_jet.intel.lua
@@ -2,15 +2,17 @@ help([[
 Build environment for GFS utilities on Jet
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-intel/install/modulefiles/Core")
+--Compiler and MPI versions
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
-local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+--Spack-stack root path and environment name
+stack_root=os.getenv("stack_root") or "/contrib/spack-stack"
+stack_env=os.getenv("stack_env") or "ue-intel-" .. stack_intel_ver
 
-load(pathJoin("stack-intel", stack_intel_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-load(pathJoin("cmake", cmake_ver))
+--Stack compiler and MPI modules to load
+stack_compiler=os.getenv("stack_compiler") or pathJoin("stack-intel", stack_intel_ver)
+stack_mpi=os.getenv("stack_mpi") or pathJoin("stack-intel-oneapi-mpi", stack_impi_ver)
 
 load("gfsutils_common")
 

--- a/modulefiles/gfsutils_noaacloud.intel.lua
+++ b/modulefiles/gfsutils_noaacloud.intel.lua
@@ -2,16 +2,17 @@ help([[
 Build environment for GFS utilities on NOAA Cloud
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+--Compiler and MPI versions
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.3.0"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.3.0"
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.3.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.3.0"
-local cmake_ver=os.getenv("cmake_ver") or "3.20.1"
+--Spack-stack root path and environment name
+stack_root=os.getenv("stack_root") or "/contrib/spack-stack"
+stack_env=os.getenv("stack_env") or "ue-intel-" .. stack_intel_ver
 
-load(pathJoin("stack-intel", stack_intel_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-load(pathJoin("cmake", cmake_ver))
+--Stack compiler and MPI modules to load
+stack_compiler=os.getenv("stack_compiler") or pathJoin("stack-intel", stack_intel_ver)
+stack_mpi=os.getenv("stack_mpi") or pathJoin("stack-intel-oneapi-mpi", stack_impi_ver)
 
 load("gfsutils_common")
 

--- a/modulefiles/gfsutils_orion.intel.lua
+++ b/modulefiles/gfsutils_orion.intel.lua
@@ -2,20 +2,17 @@ help([[
 Build environment for GFS utilities on Orion
 ]])
 
--- Spack Stack installation specs
-local ss_dir="/work/noaa/epic/role-epic/spack-stack/orion"
-local ss_ver=os.getenv("stack_ver") or "1.6.0"
-local ss_env=os.getenv("stack_env") or "gsi-addon-env-rocky9"
+--Compiler and MPI versions
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.9.0"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"
 
-prepend_path("MODULEPATH", pathJoin(ss_dir, "spack-stack-" .. ss_ver, "envs", ss_env, "install/modulefiles/Core"))
+--Spack-stack root path and environment name
+stack_root=os.getenv("stack_root") or "/work/noaa/role-epic/spack-stack/orion"
+stack_env=os.getenv("stack_env") or "ue-intel-" .. stack_intel_ver
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.9.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"
-local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
-
-load(pathJoin("stack-intel", stack_intel_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-load(pathJoin("cmake", cmake_ver))
+--Stack compiler and MPI modules to load
+stack_compiler=os.getenv("stack_compiler") or pathJoin("stack-intel", stack_intel_ver)
+stack_mpi=os.getenv("stack_mpi") or pathJoin("stack-intel-oneapi-mpi", stack_impi_ver)
 
 load("gfsutils_common")
 

--- a/modulefiles/gfsutils_s4.intel.lua
+++ b/modulefiles/gfsutils_s4.intel.lua
@@ -2,17 +2,19 @@ help([[
 Build environment for GFS utilities on S4
 ]])
 
-prepend_path("MODULEPATH", "/data/prod/jedi/spack-stack/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+--Compiler and MPI versions
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.0"
+
+--Spack-stack root path and environment name
+stack_root=os.getenv("stack_root") or "/data/prod/jedi/spack-stack"
+stack_env=os.getenv("stack_env") or "ue-intel-" .. stack_intel_ver
+
+--Stack compiler and MPI modules to load
+stack_compiler=os.getenv("stack_compiler") or pathJoin("stack-intel", stack_intel_ver)
+stack_mpi=os.getenv("stack_mpi") or pathJoin("stack-intel-oneapi-mpi", stack_impi_ver)
 
 load("license_intel")
-
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.0"
-local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
-
-load(pathJoin("stack-intel", stack_intel_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-load(pathJoin("cmake", cmake_ver))
 
 load("gfsutils_common")
 

--- a/modulefiles/gfsutils_wcoss2.intel.lua
+++ b/modulefiles/gfsutils_wcoss2.intel.lua
@@ -13,7 +13,7 @@ local zlib_ver=os.getenv("zlib_ver") or "1.2.11"
 local libpng_ver=os.getenv("libpng_ver") or "1.6.37"
 local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 
-local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
+local bufr_ver=os.getenv("bufr_ver") or "12.1.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 local sp_ver=os.getenv("sp_ver") or "2.3.3"

--- a/modulefiles/rdbfmsua_hera.intel.lua
+++ b/modulefiles/rdbfmsua_hera.intel.lua
@@ -2,16 +2,16 @@ help([[
 Build environment for GFS utilities on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.8.0/envs/ue-intel-2021.5.0/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
-local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 
-local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
+local bufr_ver=os.getenv("bufr_ver") or "12.1.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
 local gempak_ver=os.getenv("gempak_ver") or "7.4.2"

--- a/modulefiles/rdbfmsua_hera.intel.lua
+++ b/modulefiles/rdbfmsua_hera.intel.lua
@@ -2,7 +2,7 @@ help([[
 Build environment for GFS utilities on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.8.0/envs/ue-intel-2021.5.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.8.0/envs/ue-intel-2021.5.0/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"

--- a/modulefiles/rdbfmsua_orion.intel.lua
+++ b/modulefiles/rdbfmsua_orion.intel.lua
@@ -4,8 +4,8 @@ Build environment for GFS utilities on Orion
 
 -- Spack Stack installation specs
 local ss_dir="/work/noaa/epic/role-epic/spack-stack/orion"
-local ss_ver=os.getenv("stack_ver") or "1.6.0"
-local ss_env=os.getenv("stack_env") or "gsi-addon-env-rocky9"
+local ss_ver=os.getenv("stack_ver") or "1.8.0"
+local ss_env=os.getenv("stack_env") or "ue-intel-2021.9.0"
 
 prepend_path("MODULEPATH", pathJoin(ss_dir, "spack-stack-" .. ss_ver, "envs", ss_env, "install/modulefiles/Core"))
 
@@ -15,7 +15,7 @@ local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 
-local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
+local bufr_ver=os.getenv("bufr_ver") or "12.1.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
 local gempak_ver=os.getenv("gempak_ver") or "7.5.1"

--- a/src/tave.fd/CMakeLists.txt
+++ b/src/tave.fd/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 set(exe_name tave.x)
 add_executable(${exe_name} ${fortran_src})
 target_link_libraries(${exe_name} PRIVATE bacio::bacio_4
-                                          w3emc::w3emc_d
                                           g2::g2_d)
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/vint.fd/CMakeLists.txt
+++ b/src/vint.fd/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 set(exe_name vint.x)
 add_executable(${exe_name} ${fortran_src})
 target_link_libraries(${exe_name} PRIVATE bacio::bacio_4
-                                          w3emc::w3emc_d
                                           g2::g2_d)
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
# Description
Upgrades gfs-utils to spack-stack 1.8.0 and restructures the module files to make them more portable and easier to upgrade for future releases of spack-stack.

Note that this version upgrade requires ip/5.0.0 on WCOSS2 or modifications to the CMake recipes.  For now, I am assuming that ip/5.0.0 will be installed relatively soon.

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Built on Hera, additional tests will come when the whole global-workflow is upgraded.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary