### PR TITLE
Update spack-stack install path for Hera

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - if: ${{ always() }}
         name: Upload artifact with ShellCheck defects in SARIF format
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}

--- a/modulefiles/gfsutils_hera.intel.lua
+++ b/modulefiles/gfsutils_hera.intel.lua
@@ -2,7 +2,7 @@ help([[
 Build environment for GFS utilities on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"


### PR DESCRIPTION
# Description
This updates the installation path for spack-stack on Hera in preparation for the migration from /scratch(1/2) to /scratch(3/4).

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- [ ] Test build on Hera.
- [ ] Run a cycled test on Hera with this branch.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes