### PR TITLE
Fix for segmentation fault when running wave_stat.x in the global workflow

### DIFF
--- a/src/wave_stat.fd/wave_stat.f90
+++ b/src/wave_stat.fd/wave_stat.f90
@@ -29,7 +29,7 @@
       integer :: ymdc,fhr,nnme,nnsc
       integer :: parcode(3)
       integer :: istop
-      real,allocatable :: dumy1d(:)
+      real(8),allocatable :: dumy1d(:)
 ! Grid
       real    :: rdlon(3),rdlat(3)
       integer :: nlola(2)


### PR DESCRIPTION
# Description
change single to double precision in wave_stat.f90 to fix segmentation faults. Credit to @AminIlia-NOAA for pointing out the same issue he had with oceanicepost job and how it was fixed there.

  Resolves #98 
  

# Type of change
<!-- Delete all except one -->
- Bug fix 

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Same testing as documented in issue #98 was conducted with the new wave_stat.x created after the change and the wave_stat job did not crash.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
