### PR TITLE
Append 3D data to existing grib2 file in ocnicepost utility

### DIFF
--- a/src/ocnicepost.fd/ocnicepost.F90
+++ b/src/ocnicepost.fd/ocnicepost.F90
@@ -262,9 +262,6 @@ program ocnicepost
 !--------------------------------------------------------
 
   if(write_grib2) then
-   gout = trim(ftype)//'.'//trim(fdst)//'.grb2'
-   if (debug) write(logunit, '(a)')'GRIB2 2D output file: '//trim(gout)
-
    if (allocated(rgb2d) .and. allocated(rgc2d)) then
       allocate(grib2d(nxr*nyr,nconsd2d+nbilin2d), source=0.0)
       allocate(g2d(1:nconsd2d+nbilin2d)) 
@@ -284,12 +281,12 @@ program ocnicepost
       g2d(1:nbilin2d) = b2d
    end if
 
+   gout = trim(ftype)//'.'//trim(fdst)//'.grib2'
+   if (debug) write(logunit, '(a)')'GRIB2 output file: '//trim(gout)
    call write_grib2_2d(gout, g2d, (/nxr,nyr/), nconsd2d+nbilin2d, grib2d, vfill)
 
    if (allocated(rgb3d)) then
-      gout = trim(ftype)//'.'//trim(fdst)//'_3D.grb2'
       call write_grib2_3d(gout, b3d, (/nxr,nyr,nlevs/), nbilin3d, rgb3d, vfill)
-      if (debug) write(logunit, '(a)')'GRIB2 3D output file: '//trim(gout)
    end if
   end if
 

--- a/src/ocnicepost.fd/utils_mod.F90
+++ b/src/ocnicepost.fd/utils_mod.F90
@@ -869,7 +869,7 @@ contains
    bmp=.true.
 
    call getlun(lunout)
-   call baopenw(lunout, trim(fname), ierr)
+   call baopenwa(lunout, trim(fname), ierr)
    if (ierr /= 0) then
        write(0, *) 'Error opening grib2 file ', trim(fname)
        return


### PR DESCRIPTION
This PR:
- appends the 3D output to the existing grib2 file created
- will eliminate the need to concatenate 2D and 3D grib2 files for the final product (ocean) in the workflow
- makes use of `baopenwa` to append and write to existing grib2 file
- does not change the behaviour of netcdf output

# Type of change
- New feature

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
The code was ran on Hera.  
The output file sizes of the combined file is exactly identical to the one obtained by `cat`.

The output requires independent verification.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
