### PR TITLE
Add gcc version and maintain gnu stack on cloud

### DIFF
--- a/modulefiles/gfsutils_noaacloud.intel.lua
+++ b/modulefiles/gfsutils_noaacloud.intel.lua
@@ -5,14 +5,14 @@ Build environment for GFS utilities on NOAA Cloud
 prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
+local gcc_ver=os.getenv("gcc_ver") or "13.2.0"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 
-load("gnu")
+load(pathJoin("gnu", gcc_ver))
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-unload("gnu")
 
 load(pathJoin("cmake", cmake_ver))
 


### PR DESCRIPTION
<!-- PLEASE READ -->
<!-- Any PRs not following this template will be closed -->
<!--
    Please use a short (<60 char), descriptive title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

    PRs should meet these guidelines:
    - Each PR should address ONE topic and have an associated issue.
    - No hard-coded paths or personal directories.
    - No temporary or backup files should be committed (including logs).
    - Any code that you disabled by being commented out should be removed or reenabled.

    Please delete all these comments before submitting the PR.
-->
# Description
<!-- This description will become the commit message for the PR-->
<!-- Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->

This PR removes the unloading of `gnu` from the cloud module file.  Loading `gnu` adds GCC libraries and tools to the necessary paths that are needed in the stack. There are different GCC version defaults on the legacy versus latest NOAA RDHPCS cloud `/apps` snapshots (13.2.0 for legacy, 14.2.0 for latest), and these different version module files have different configurations so that the GCC version is specified as 13.2.0 to have consistency across the different `/apps` mounts. 

Resolves #119 

# Type of change
<!-- Delete all except one -->
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test with workflow with bufr and gempak on
-->

I cloned and ran the build script on PW AWS with latest `/apps` snapshot mounted. I am not currently able to test with the legacy `/apps` snapshot, but the GCC default version is specified as 13.2.0 in this PR which is the default GCC version on the legacy `/apps` snapshot so that the build should finish successfully regardless of which `/apps` snapshot is mounted.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
