### PR TITLE
Add SFS 6-hourly grib2 products for selected variables

### DIFF
--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -25,9 +25,9 @@ declare -a filevars=( "dlwrfsfc" "dswrfsfc" "ulwrfsfc" "uswrfsfc" "ulwrftoa" "lh
 "spfh925mb" "tmp50mb" "tmp200mb" "tmp500mb" "tmp700mb" "tmp850mb" "tcdc" "icec" "tsoil10cm" "soilm" "watr" "weasd" "land" "hgtsfc" "wind10m" "wind200mb" "wind500mb" "wind700mb" "wind850mb" "wind925mb" "flux" )
 
 # get validation date of first file
-firstfile=$memdir/sfs.t${cc}z.master.grb2f000
-vt_init=$(wgrib2 $firstfile -d 1 -vt)
-vt_date=${vt_init:7:10}  # for filename
+firstfile="$memdir/sfs.t${cc}z.master.grb2f000"
+vt_init="$(wgrib2 $firstfile -d 1 -vt)"
+vt_date="${vt_init:7:10}"  # for filename
 
 for (( i=0; i<${#vars[@]}; i++)); do
   
@@ -36,10 +36,10 @@ for (( i=0; i<${#vars[@]}; i++)); do
 
   filename="${filevar}.${ens}.${vt_date}.6hourly.grb2"
  
-  cat $(eval "ls -v $memdir/*") | wgrib2 - -match "${var}" -grib $outdir/IN.grb
+  cat $(eval "ls -v $memdir/*") | wgrib2 - -match "${var}" -grib "$outdir/IN.grb"
 
-  wgrib2 $outdir/IN.grb -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "$outdir/$filename"
-  rm $outdir/IN.grb
+  wgrib2 "$outdir/IN.grb" -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "$outdir/$filename"
+  rm "$outdir/IN.grb"
 
 done
 

--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -26,7 +26,7 @@ declare -a filevars=( "dlwrfsfc" "dswrfsfc" "ulwrfsfc" "uswrfsfc" "ulwrftoa" "lh
 
 # get validation date of first file
 firstfile="$memdir/sfs.t${cc}z.master.grb2f000"
-vt_init="$(wgrib2 $firstfile -d 1 -vt)"
+vt_init="$(wgrib2 ${firstfile} -d 1 -vt)"
 vt_date="${vt_init:7:10}"  # for filename
 
 for (( i=0; i<${#vars[@]}; i++)); do

--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -11,10 +11,10 @@
 # THIS SCRIPT WILL BE CALLED FROM G-W JOBS, WHERE THE FOLLOWING VARIABLES WILL BE
 # PREDETERIMED:
 
-###  memdir: path to directory with the SFS master files for a member
-###  cc: cycle of memdir data
-###  ens: ensemble member of memdir data
-###  outdir: path to directory where 6hourly files will be saved
+###  MEMDIR: path to directory with the SFS master files for a member
+###  CC: cycle of MEMDIR data
+###  ENS: ensemble member of MEMDIR data
+###  OUTDIR: path to directory where 6hourly files will be saved
 
 #####################################################################################
 
@@ -25,7 +25,7 @@ declare -a filevars=( "dlwrfsfc" "dswrfsfc" "ulwrfsfc" "uswrfsfc" "ulwrftoa" "lh
 "spfh925mb" "tmp50mb" "tmp200mb" "tmp500mb" "tmp700mb" "tmp850mb" "tcdc" "icec" "tsoil10cm" "soilm" "watr" "weasd" "land" "hgtsfc" "wind10m" "wind200mb" "wind500mb" "wind700mb" "wind850mb" "wind925mb" "flux" )
 
 # get validation date of first file
-firstfile="$memdir/sfs.t${cc}z.master.grb2f000"
+firstfile="$MEMDIR/sfs.t${CC}z.master.grb2f000"
 vt_init="$(wgrib2 ${firstfile} -d 1 -vt)"
 vt_date="${vt_init:7:10}"  # for filename
 
@@ -34,12 +34,12 @@ for (( i=0; i<${#vars[@]}; i++)); do
   var="${vars[$i]}"
   filevar="${filevars[$i]}"
 
-  filename="${filevar}.${ens}.${vt_date}.6hourly.grb2"
+  filename="${filevar}.${ENS}.${vt_date}.6hourly.grb2"
  
-  cat $(eval "ls -v $memdir/*") | wgrib2 - -match "${var}" -grib "$outdir/IN.grb"
+  cat $(eval "ls -v $MEMDIR/*") | wgrib2 - -match "${var}" -grib "$OUTDIR/IN.grb"
 
-  wgrib2 "$outdir/IN.grb" -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "$outdir/$filename"
-  rm "$outdir/IN.grb"
+  wgrib2 "$OUTDIR/IN.grb" -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "$OUTDIR/$filename"
+  rm "$OUTDIR/IN.grb"
 
 done
 

--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+######################################################################################
+
+# GENERATE 6-HOURLY GRIB2 FILES ON INTERPOLATED 360-x181 LAT-LON  GRID 
+# FOR SELECT SFS VARIABLES
+
+# THIS SCRIPT READS ALL GRIB2 FILES FOR A GIVEN SFS FORECAST PERIOD TO GENERATE
+# A SINGLE FILE PER VARIABLE WITH ALL 6-HOURLY FORECASTS
+
+# THIS SCRIPT WILL BE CALLED FROM G-W JOBS, WHERE THE FOLLOWING VARIABLES WILL BE
+# PREDETERIMED:
+
+###  memdir: path to directory with the SFS master files for a member
+###  cc: cycle of memdir data
+###  ens: ensemble member of memdir data
+###  outdir: path to directory where 6hourly files will be saved
+
+#####################################################################################
+
+declare -a vars=( "DLWRF:surface" "DSWRF:surface" "ULWRF:surface" "USWRF:surface" "ULWRF:top of atmosphere" "LHTFL" "SHTFL" "PRMSL" "PRATE" ":TMP:2 m above" "TMAX:2 m above" "TMIN:2 m above" "DPT:2 m above" "HGT:200 mb" "HGT:500 mb" "HGT:700 mb" "HGT:850 mb" "SPFH:500 mb" "SPFH:700 mb" "SPFH:850 mb" 
+"SPFH:925 mb" ":TMP:50 mb" ":TMP:200 mb" ":TMP:500 mb" ":TMP:700 mb" ":TMP:850 mb" "TCDC" "ICEC" "TSOIL:0-0.1" "SOILM" "WATR" "WEASD" "LAND" "HGT:surface" "(UGRD|VGRD):10 m above" "(UGRD|VGRD):200 mb" "(UGRD|VGRD):500 mb" "(UGRD|VGRD):700 mb" "(UGRD|VGRD):850 mb" "(UGRD|VGRD):925 mb" "(UFLX|VFLX)" ) 
+
+declare -a filevars=( "dlwrfsfc" "dswrfsfc" "ulwrfsfc" "uswrfsfc" "ulwrftoa" "lhtflsfc" "shtflsfc" "prmsl" "prate" "tmp2m" "tmax2m" "tmin2m" "dpt2m" "hgt200mb" "hgt500mb" "hgt700mb" "hgt850mb" "spfh500mb" "spfh700mb" "spfh850mb" 
+"spfh925mb" "tmp50mb" "tmp200mb" "tmp500mb" "tmp700mb" "tmp850mb" "tcdc" "icec" "tsoil10cm" "soilm" "watr" "weasd" "land" "hgtsfc" "wind10m" "wind200mb" "wind500mb" "wind700mb" "wind850mb" "wind925mb" "flux" )
+
+# get validation date of first file
+firstfile=$memdir/sfs.t${cc}z.master.grb2f000
+vt_init=$(wgrib2 $firstfile -d 1 -vt)
+vt_date=${vt_init:7:10}  # for filename
+
+for (( i=0; i<${#vars[@]}; i++)); do
+  
+  var="${vars[$i]}"
+  filevar="${filevars[$i]}"
+
+  filename="${filevar}.${ens}.${vt_date}.6hourly.grb2"
+ 
+  cat $(eval "ls -v $memdir/*") | wgrib2 - -match "${var}" -grib $outdir/IN.grb
+
+  wind="UGRD"
+  flux="UFLX"
+  if [[ "$var" == *"$wind"* ]]; then
+    name=${var/(UGRD|VGRD)/WIND}
+  elif [[ "$var" == *"$flux"* ]]; then
+    name=${var/(UFLX|VFLX)/FLUX}
+  else
+    name="$var"
+  fi
+
+  wgrib2 $outdir/IN.grb -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "$outdir/$filename"
+  rm $outdir/IN.grb
+
+done
+

--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -38,16 +38,6 @@ for (( i=0; i<${#vars[@]}; i++)); do
  
   cat $(eval "ls -v $memdir/*") | wgrib2 - -match "${var}" -grib $outdir/IN.grb
 
-  wind="UGRD"
-  flux="UFLX"
-  if [[ "$var" == *"$wind"* ]]; then
-    name=${var/(UGRD|VGRD)/WIND}
-  elif [[ "$var" == *"$flux"* ]]; then
-    name=${var/(UFLX|VFLX)/FLUX}
-  else
-    name="$var"
-  fi
-
   wgrib2 $outdir/IN.grb -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "$outdir/$filename"
   rm $outdir/IN.grb
 

--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -35,7 +35,9 @@ for (( i=0; i<${#vars[@]}; i++)); do
   filevar="${filevars[$i]}"
 
   filename="${filevar}.${ENS}.${vt_date}.6hourly.grb2"
- 
+
+   # shellcheck disable=SC2046
+   # shellcheck disable=SC2002
   cat $(eval "ls -v ${MEMDIR}/*") | wgrib2 - -match "${var}" -grib "${OUTDIR}/IN.grb"
 
   wgrib2 "${OUTDIR}/IN.grb" -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "${OUTDIR}/${filename}"

--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -25,7 +25,7 @@ declare -a filevars=( "dlwrfsfc" "dswrfsfc" "ulwrfsfc" "uswrfsfc" "ulwrftoa" "lh
 "spfh925mb" "tmp50mb" "tmp200mb" "tmp500mb" "tmp700mb" "tmp850mb" "tcdc" "icec" "tsoil10cm" "soilm" "watr" "weasd" "land" "hgtsfc" "wind10m" "wind200mb" "wind500mb" "wind700mb" "wind850mb" "wind925mb" "flux" )
 
 # get validation date of first file
-firstfile="$MEMDIR/sfs.t${CC}z.master.grb2f000"
+firstfile="${MEMDIR}/sfs.t${CC}z.master.grb2f000"
 vt_init="$(wgrib2 "${firstfile}" -d 1 -vt)"
 vt_date="${vt_init:7:10}"  
 

--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -26,8 +26,8 @@ declare -a filevars=( "dlwrfsfc" "dswrfsfc" "ulwrfsfc" "uswrfsfc" "ulwrftoa" "lh
 
 # get validation date of first file
 firstfile="$MEMDIR/sfs.t${CC}z.master.grb2f000"
-vt_init="$(wgrib2 ${firstfile} -d 1 -vt)"
-vt_date="${vt_init:7:10}"  # for filename
+vt_init="$(wgrib2 "${firstfile}" -d 1 -vt)"
+vt_date="${vt_init:7:10}"  
 
 for (( i=0; i<${#vars[@]}; i++)); do
   
@@ -36,10 +36,10 @@ for (( i=0; i<${#vars[@]}; i++)); do
 
   filename="${filevar}.${ENS}.${vt_date}.6hourly.grb2"
  
-  cat $(eval "ls -v $MEMDIR/*") | wgrib2 - -match "${var}" -grib "$OUTDIR/IN.grb"
+  cat $(eval "ls -v ${MEMDIR}/*") | wgrib2 - -match "${var}" -grib "${OUTDIR}/IN.grb"
 
-  wgrib2 "$OUTDIR/IN.grb" -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "$OUTDIR/$filename"
-  rm "$OUTDIR/IN.grb"
+  wgrib2 "${OUTDIR}/IN.grb" -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "${OUTDIR}/$filename"
+  rm "${OUTDIR}/IN.grb"
 
 done
 

--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -38,7 +38,7 @@ for (( i=0; i<${#vars[@]}; i++)); do
  
   cat $(eval "ls -v ${MEMDIR}/*") | wgrib2 - -match "${var}" -grib "${OUTDIR}/IN.grb"
 
-  wgrib2 "${OUTDIR}/IN.grb" -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "${OUTDIR}/$filename"
+  wgrib2 "${OUTDIR}/IN.grb" -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "${OUTDIR}/${filename}"
   rm "${OUTDIR}/IN.grb"
 
 done


### PR DESCRIPTION
# Description
This PR addresses Issue #130 . It provides a script for generating grib2 files for selected SFS variables at 6-hourly intervals for a full forecast, as requested by CPC. The script is meant to be called from an outside job in g-w specifying certain variables to be imported.

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
The script has been tested with sample SFS 6-hourly data, and the results have been validated by CPC. The test results are in WCOSS2: /lfs/h2/emc/vpppg/noscrub/karina.asmar/6hrly_tests/vars_6hrly. The sample run script used to call the script submitted in this PR is /lfs/h2/emc/vpppg/noscrub/karina.asmar/6hrly_tests/run_script_6hrly.sh.

-->

# Checklist
- [x ] Any dependent changes have been merged and published
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ x] New and existing tests pass with my changes
- [ x] I have made corresponding changes to the documentation if necessary
