### PR TITLE
Add budget interpolation to PRATE for SFS 6-hourly files

### DIFF
--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -41,7 +41,7 @@ for (( i=0; i<${#vars[@]}; i++)); do
   cat $(eval "ls -v ${MEMDIR}/*") | wgrib2 - -match "${var}" -grib "${OUTDIR}/IN.grb"
 
   # interpolate: bilinear for all except PRATE which uses budget
-  wgrib2 "${OUTDIR}/IN.grb" -if ':(PRATE|CPRAT|CPOFP|TSNOWP|ACPCP|APCP|NCPCP):' -new_grid_interpolation budget -fi -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "${OUTDIR}/${filename}"
+  wgrib2 "${OUTDIR}/IN.grb" -if ':PRATE:' -new_grid_interpolation budget -fi -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "${OUTDIR}/${filename}"
   rm "${OUTDIR}/IN.grb"
 
 done

--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -40,7 +40,8 @@ for (( i=0; i<${#vars[@]}; i++)); do
    # shellcheck disable=SC2002
   cat $(eval "ls -v ${MEMDIR}/*") | wgrib2 - -match "${var}" -grib "${OUTDIR}/IN.grb"
 
-  wgrib2 "${OUTDIR}/IN.grb" -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "${OUTDIR}/${filename}"
+  # interpolate: bilinear for all except PRATE which uses budget
+  wgrib2 "${OUTDIR}/IN.grb" -if ':(PRATE|CPRAT|CPOFP|TSNOWP|ACPCP|APCP|NCPCP):' -new_grid_interpolation budget -fi -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "${OUTDIR}/${filename}"
   rm "${OUTDIR}/IN.grb"
 
 done


### PR DESCRIPTION
# Description
This PR adds budget interpolation for the precipitation variable PRATE instead of using the default bilinear.

Resolved #132 
-->

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES
- Does this change require a documentation update? NO

# How has this been tested?
The script was tested on SFS 6-hourly forecast data. Results are in /lfs/h2/emc/vpppg/noscrub/karina.asmar/mm_tests/vars_6hrly_tests/vars.6hrly.20121101

Submit /lfs/h2/emc/vpppg/noscrub/karina.asmar/mm_tests/vars_6hrly_tests/run_script_6hrly.sh as a job, which calls sfs_6hrly_vars.sh (script submitted in this PR) and generates the 6-hourly grib2 files.
-->

# Checklist
- [ x] Any dependent changes have been merged and published
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ x] New and existing tests pass with my changes
- [ x] I have made corresponding changes to the documentation if necessary
