### PR TITLE
Add imp_physics and landsfcmdl to gaussian sfcanl attributes (#147)

### DIFF
--- a/src/gaussian_sfcanl.fd/gaussian_sfcanl.f90
+++ b/src/gaussian_sfcanl.fd/gaussian_sfcanl.f90
@@ -40,7 +40,7 @@
 
  integer, parameter :: num_tiles = 6
 
- integer :: itile, jtile, igaus, jgaus
+ integer :: itile, jtile, igaus, jgaus, imp_physics, landsfcmdl
 
  integer :: idate(8)
 
@@ -126,7 +126,7 @@
  real, parameter           :: fill = 0.0
  real(kind=8), allocatable :: s(:)
 
- namelist /setup/ yy, mm, dd, hh, igaus, jgaus, donst
+ namelist /setup/ yy, mm, dd, hh, igaus, jgaus, donst, imp_physics, landsfcmdl
 
  call w3tagb('GAUSSIAN_SFCANL',2018,0179,0055,'NP20')
 
@@ -758,6 +758,12 @@
 
  error = nf90_put_att(ncid, nf90_global, 'jm', jgaus)
  call netcdf_err(error, 'DEFINING JM ATTRIBUTE')
+
+ error = nf90_put_att(ncid, nf90_global, 'imp_physics', imp_physics)
+ call netcdf_err(error, 'DEFINING IMP_PHYSICS ATTRIBUTE')
+
+ error = nf90_put_att(ncid, nf90_global, 'landsfcmdl', landsfcmdl)
+ call netcdf_err(error, 'DEFINING LANDSFCMDL ATTRIBUTE')
 
 ! variables
 


### PR DESCRIPTION
# Description
The gaussian grid sfcanl file does not have the needed global attributes for upp. The attributes of imp_physics and landsfcmdl are missing and needed for upp to compute cloud and land fields consistently with the model. Upp assumes default values but the imp_physics default is inconsistent with what is used in GFSv17.

Resolves #147 
Refs https://github.com/NOAA-EMC/global-workflow/issues/4113

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Global-workflow CI tests (including cycling) on WCOSS2 as well as standalone UPP tests by @WenMeng-NOAA 

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
