### PR TITLE
Remove interpolation on SFS 6-hourly products

### DIFF
--- a/ush/sfs_6hrly_vars.sh
+++ b/ush/sfs_6hrly_vars.sh
@@ -2,8 +2,7 @@
 
 ######################################################################################
 
-# GENERATE 6-HOURLY GRIB2 FILES ON INTERPOLATED 360-x181 LAT-LON  GRID 
-# FOR SELECT SFS VARIABLES
+# GENERATE 6-HOURLY GRIB2 FILES FOR SELECTED SFS VARIABLES.
 
 # THIS SCRIPT READS ALL GRIB2 FILES FOR A GIVEN SFS FORECAST PERIOD TO GENERATE
 # A SINGLE FILE PER VARIABLE WITH ALL 6-HOURLY FORECASTS
@@ -38,11 +37,7 @@ for (( i=0; i<${#vars[@]}; i++)); do
 
    # shellcheck disable=SC2046
    # shellcheck disable=SC2002
-  cat $(eval "ls -v ${MEMDIR}/*") | wgrib2 - -match "${var}" -grib "${OUTDIR}/IN.grb"
-
-  # interpolate: bilinear for all except PRATE which uses budget
-  wgrib2 "${OUTDIR}/IN.grb" -if ':PRATE:' -new_grid_interpolation budget -fi -new_grid_winds earth -new_grid latlon 0:360:1 90:181:-1 "${OUTDIR}/${filename}"
-  rm "${OUTDIR}/IN.grb"
+  cat $(eval "ls -v ${MEMDIR}/*") | wgrib2 - -match "${var}" -grib "${OUTDIR}/${filename}"
 
 done
 


### PR DESCRIPTION
# Description
This PR removes the interpolation piece from the SFS 6-hourly products utility. The interpolation will be done directly on SFS master files, as discussed with the EMC model team, so no interpolation is needed on this utility.

Resolves #145 

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES
- Does this change require a documentation update? YES

# How has this been tested?
Tested on SFS master files, originally on Gaussian grid. Results in **/lfs/h2/emc/vpppg/noscrub/karina.asmar/mm_tests/vars_6hrly_tests/vars.6hrly.20121101** show 6-hourly products files also on the Gaussian grid (e.g., no interpolation).

# Checklist
- [ x] Any dependent changes have been merged and published
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ x] New and existing tests pass with my changes
- [ x] I have made corresponding changes to the documentation if necessary
