### PR TITLE
Bug fix for loop boundary that caused array index greater than upper bound

### DIFF
--- a/src/ocnicepost.fd/utils_mod.F90
+++ b/src/ocnicepost.fd/utils_mod.F90
@@ -114,7 +114,7 @@ contains
 
     if (debug)write(logunit,'(a)')'enter '//trim(subname)
     ! obtain vector pairs
-    do n = 1,dims(3)
+    do n = 1,nflds
        if (trim(vars(n)%var_grid) == 'Cu') then
           allocate(vecpair(dims(1)*dims(2),dims(3),2)); vecpair = 0.0
           call getvecpair(trim(filesrc), trim(wgtsdir), cosrot, sinrot, &


### PR DESCRIPTION

# Description

This PR fixes the bug in src/ocnicepost.fd/utils_mod.F90 where the loop boundary was set incorrectly and caused index of array VARS greater than the upper bound.
 
  Resolves #151 
  Refs https://github.com/NOAA-EMC/GFS/issues/31

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Tested with workflow with on WCOSS2


# Checklist
- [v ] Any dependent changes have been merged and published
- [v ] My code follows the style guidelines of this project
- [v ] I have performed a self-review of my own code
- [v ] I have commented my code, particularly in hard-to-understand areas
- [v ] My changes generate no new warnings
- [v ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
