### PR TITLE
Fix array out of bounds error in gfs_bufr  

### DIFF
--- a/src/gfs_bufr.fd/meteorg.f
+++ b/src/gfs_bufr.fd/meteorg.f
@@ -164,11 +164,11 @@
           error=nf90_open(trim(fnsig),nf90_nowrite,ncid)
           error=nf90_get_att(ncid,nf90_global,"ak",vdummy)
            do k = 1, levs+1
-            vcoord(k,1)=vdummy(levs-k+1)
+            vcoord(k,1)=vdummy(levs-k+2)
            enddo
           error=nf90_get_att(ncid,nf90_global,"bk",vdummy)
            do k = 1, levs+1
-            vcoord(k,2)=vdummy(levs-k+1)
+            vcoord(k,2)=vdummy(levs-k+2)
            enddo
           error=nf90_inq_varid(ncid, "time", id_var)
           error=nf90_get_var(ncid, id_var, nfhour)
@@ -378,7 +378,7 @@
           end do
         end do
       do k=2,levs+1
-         kk=levs-k+1
+         kk=levs-k+2
         do j=1,jm
           do i=1,im
             zint(i,j,k) = zint(i,j,k-1) - delpz(i,j,kk)
@@ -544,7 +544,7 @@
      +          dum2d(im/2,jm/4,8),dum2d(im/2,jm/3,8)
         if(debugprint)
      +   print*,'evaporation latent heat net flux stn 000692)= ',
-     +          dum2d(2239,441,8)
+     +          dum2d(22,41,8)
 
 ! total precip
        if ( nf .le. nend1 ) then
@@ -657,8 +657,8 @@
         rdum=rlon(np)
         if(rdum<0.)rdum=rdum+360.
 
-        do j=1,jm-1
-         do i=1,im-1
+        do j=4,jm-3
+         do i=4,im-3
           if((rdum>=gdlon(i,j) .and. rdum<=gdlon(i+1,j)) .and.
      +    (rlat(np)<=gdlat(i,j).and.rlat(np)>=gdlat(i,j+1)) ) then
               if(landwater(np) == 2)then


### PR DESCRIPTION
# Description
<!-- This description will become the commit message for the PR-->
   This PR is to fix the array out of bounds error in code src/gfs_bufr.fd/meteorg.f.    

Resolved #150 
Refs NOAA-EMC/GFS#31
    
# Type of change
<!-- Delete all except one -->
 - Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
-  Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
