### PR TITLE
Add utility to compute NSST increment for GCAFS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(syndat_qctropcy.fd)
 add_subdirectory(syndat_maksynrc.fd)
 add_subdirectory(syndat_getjtbul.fd)
 add_subdirectory(supvit.fd)
+add_subdirectory(tref_calc.fd)
 
 add_subdirectory(mkgfsawps.fd)
 add_subdirectory(overgridid.fd)

--- a/src/tref_calc.fd/CMakeLists.txt
+++ b/src/tref_calc.fd/CMakeLists.txt
@@ -1,0 +1,28 @@
+list(APPEND fortran_src
+driver.f90
+input_data.f90
+interp.F90
+output_data.f90
+setup.f90
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model precise")
+endif()
+
+set(exe_name tref_calc.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(${exe_name} PRIVATE NetCDF::NetCDF_Fortran
+                                          bacio::bacio_4
+                                          ip::ip_4
+                                          w3emc::w3emc_4
+                                          ncio::ncio)
+if(OpenMP_Fortran_FOUND)
+  target_link_libraries(${exe_name} PRIVATE OpenMP::OpenMP_Fortran)
+endif()
+
+if(ip_VERSION VERSION_GREATER_EQUAL 4.0.0)
+   target_compile_definitions(${exe_name} PRIVATE "IP_V4")
+endif()
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/tref_calc.fd/CMakeLists.txt
+++ b/src/tref_calc.fd/CMakeLists.txt
@@ -4,6 +4,7 @@ input_data.f90
 interp.F90
 output_data.f90
 setup.f90
+utils.f90
 )
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")

--- a/src/tref_calc.fd/README.md
+++ b/src/tref_calc.fd/README.md
@@ -1,0 +1,38 @@
+# tref_calc.x
+
+This program calculates near sea surface temperature fields for the Global Constituent Data Assimilation System.
+
+## Overview
+
+This code is borrowed heavily from `enkf_chgres_recenter_nc`. It takes the Gaussian surface analysis from GDAS, regrids it to the GCDAS resolution, and differences them to compute `dtf` and writes `dtf` and `msk` to a file matching the format of the GSI output to feed into global_cycle.
+
+## Namelist Options
+
+The program uses a namelist configuration file to control its behavior. The following namelist groups and variables are supported:
+
+### tref_calc_setup
+
+- `i_output`: Number of longitudes on the target grid.
+- `j_output`: Number of latitudes on the target grid.
+- `sfcanl_file`: Path to the input GDAS Gaussian surface analysis NetCDF (source tref grid).
+- `sfcf006_file`: Path to the input forecast surface NetCDF (target tref grid and land mask).
+- `output_file`: Path to the output NetCDF file to write (`dtf`, `msk`, `latitude`, `longitude`).
+
+Example namelist file:
+
+```
+&tref_calc_setup
+	i_output    = 384,
+	j_output    = 193,
+	sfcanl_file = '/path/to/sfcanl.nc',
+	sfcf006_file= '/path/to/sfcf006.nc',
+	output_file = '/path/to/dtfanl.nc'
+/
+```
+
+Notes:
+- `dtf` is computed as the difference between `tref` on the target grid and the source `tref` interpolated to the target grid.
+- `msk` is derived from the `land` variable in the target file and written as a byte integer to match GSI output.
+- Latitude and longitude are written in degrees, with two extra latitude points appended at −90 and 90 degrees.
+
+

--- a/src/tref_calc.fd/driver.f90
+++ b/src/tref_calc.fd/driver.f90
@@ -1,0 +1,48 @@
+!!! Compute tref difference between sfcanl.nc and sfcf006.nc
+!!! Based on enkf_chgres_recenter_nc
+!!! cory.r.martin@noaa.gov 2025-12-03
+ program tref_diff
+
+ use setup, only       : program_setup
+ use interp, only      : interpolate_to_target
+ use input_data, only  : read_input_data
+ use output_data, only : write_output_data
+
+ implicit none
+
+ call w3tagb('TREF_CALC',2025,0337,0085,'NP20')
+
+ print*,"STARTING TREF_CALC PROGRAM"
+
+!--------------------------------------------------------
+! Read configuration namelist.
+!--------------------------------------------------------
+
+ call program_setup
+
+!--------------------------------------------------------
+! Read input grid data from both files
+!--------------------------------------------------------
+
+ call read_input_data
+
+!--------------------------------------------------------
+! Interpolate sfcanl.nc to resolution of sfcf006.nc
+!--------------------------------------------------------
+
+ call interpolate_to_target
+
+!--------------------------------------------------------
+! Write output data to file (difference already computed).
+!--------------------------------------------------------
+
+ call write_output_data
+
+ print*
+ print*,"TREF_CALC PROGRAM FINISHED NORMALLY!"
+
+ call w3tage('TREF_CALC')
+
+ stop
+
+ end program tref_diff

--- a/src/tref_calc.fd/driver.f90
+++ b/src/tref_calc.fd/driver.f90
@@ -1,18 +1,17 @@
-!!! Compute tref difference between sfcanl.nc and sfcf006.nc
-!!! Based on enkf_chgres_recenter_nc
-!!! cory.r.martin@noaa.gov 2025-12-03
- program tref_diff
+!!! based on enkf_chgres_recenter_nc
+!!! cory.r.martin@noaa.gov 2025-12-04
+ program tref_calc
 
  use setup, only       : program_setup
- use interp, only      : interpolate_to_target
+ use interp, only      : gaus_to_gaus
  use input_data, only  : read_input_data
- use output_data, only : write_output_data
+ use output_data, only : set_output_grid, write_output_data
 
  implicit none
 
- call w3tagb('TREF_CALC',2025,0337,0085,'NP20')
+ call w3tagb('TREF_CALC',2025,0330,0085,'NP20')
 
- print*,"STARTING TREF_CALC PROGRAM"
+ print*,"STARTING PROGRAM"
 
 !--------------------------------------------------------
 ! Read configuration namelist.
@@ -21,28 +20,34 @@
  call program_setup
 
 !--------------------------------------------------------
-! Read input grid data from both files
+! Read input grid data
 !--------------------------------------------------------
 
  call read_input_data
 
 !--------------------------------------------------------
-! Interpolate sfcanl.nc to resolution of sfcf006.nc
+! Get output grid specs
 !--------------------------------------------------------
 
- call interpolate_to_target
+ call set_output_grid
 
 !--------------------------------------------------------
-! Write output data to file (difference already computed).
+! Interpolate data to output grid
+!--------------------------------------------------------
+
+ call gaus_to_gaus
+
+!--------------------------------------------------------
+! Write output data to file.
 !--------------------------------------------------------
 
  call write_output_data
 
  print*
- print*,"TREF_CALC PROGRAM FINISHED NORMALLY!"
+ print*,"PROGRAM FINISHED NORMALLY!"
 
  call w3tage('TREF_CALC')
 
  stop
 
- end program tref_diff
+ end program tref_calc

--- a/src/tref_calc.fd/input_data.f90
+++ b/src/tref_calc.fd/input_data.f90
@@ -1,0 +1,189 @@
+ module input_data
+
+ use setup
+ use module_ncio
+
+ implicit none
+
+ private
+
+ real, allocatable, public                    :: tref_source(:)
+ real, allocatable, public                    :: tref_target(:)
+ real, allocatable, public                    :: rlat_source(:)
+ real, allocatable, public                    :: rlon_source(:)
+ real, allocatable, public                    :: rlat_target(:)
+ real, allocatable, public                    :: rlon_target(:)
+ integer, allocatable, public                 :: msk_target(:)
+
+ integer, public                              :: kgds_source(200)
+ integer, public                              :: kgds_target(200)
+
+ public                                       :: read_input_data
+
+ contains
+
+ subroutine read_input_data
+
+!-------------------------------------------------------------------------------------
+! Read tref from sfcanl.nc and sfcf006.nc
+!-------------------------------------------------------------------------------------
+
+ implicit none
+
+ type(Dataset) :: indset
+ type(Dimension) :: ncdim
+ real, allocatable                            :: work2d(:,:)
+ real, allocatable                            :: lat2d(:,:), lon2d(:,:)
+
+!-------------------------------------------------------------------------------------
+! Read source file (sfcanl.nc)
+!-------------------------------------------------------------------------------------
+
+ print*
+ print*,"OPEN SOURCE FILE: ",trim(sfcanl_file)
+ indset = open_dataset(sfcanl_file)
+
+ print*,"GET SOURCE FILE HEADER"
+ ncdim = get_dim(indset, 'grid_xt'); i_source = ncdim%len
+ ncdim = get_dim(indset, 'grid_yt'); j_source = ncdim%len
+
+ print*,'DIMENSIONS OF SOURCE DATA ARE: ', i_source, j_source
+
+ ij_source = i_source * j_source
+
+ print*
+ print*,"READ TREF FROM SOURCE FILE"
+ call read_vardata(indset, 'tref', work2d)
+
+ allocate(tref_source(ij_source))
+ tref_source = reshape(work2d,(/ij_source/))
+ print*,'MAX/MIN SOURCE TREF: ',maxval(tref_source), minval(tref_source)
+
+ deallocate(work2d)
+
+!-------------------------------------------------------------------------------------
+! Read lat/lon for source grid
+!-------------------------------------------------------------------------------------
+
+ print*,"READ SOURCE GRID LAT"
+ call read_vardata(indset, 'lat', lat2d)
+ allocate(rlat_source(ij_source))
+ rlat_source = reshape(lat2d,(/ij_source/))
+
+ print*,"READ SOURCE GRID LON"
+ call read_vardata(indset, 'lon', lon2d)
+ allocate(rlon_source(ij_source))
+ rlon_source = reshape(lon2d,(/ij_source/))
+
+ deallocate(lat2d, lon2d)
+
+ call close_dataset(indset)
+
+!-------------------------------------------------------------------------------------
+! Calculate kgds for source grid
+!-------------------------------------------------------------------------------------
+
+ kgds_source = 0
+ call calc_kgds(i_source, j_source, kgds_source)
+
+!-------------------------------------------------------------------------------------
+! Read target file (sfcf006.nc)
+!-------------------------------------------------------------------------------------
+
+ print*
+ print*,"OPEN TARGET FILE: ",trim(sfcf006_file)
+ indset = open_dataset(sfcf006_file)
+
+ print*,"GET TARGET FILE HEADER"
+ ncdim = get_dim(indset, 'grid_xt'); i_target = ncdim%len
+ ncdim = get_dim(indset, 'grid_yt'); j_target = ncdim%len
+
+ print*,'DIMENSIONS OF TARGET DATA ARE: ', i_target, j_target
+
+ ij_target = i_target * j_target
+
+ print*
+ print*,"READ TREF FROM TARGET FILE"
+ call read_vardata(indset, 'tref', work2d)
+
+ allocate(tref_target(ij_target))
+ tref_target = reshape(work2d,(/ij_target/))
+ print*,'MAX/MIN TARGET TREF: ',maxval(tref_target), minval(tref_target)
+
+ deallocate(work2d)
+
+ print*
+ print*,"READ LAND MASK FROM TARGET FILE"
+ call read_vardata(indset, 'land', work2d)
+
+ allocate(msk_target(ij_target))
+ msk_target = nint(reshape(work2d,(/ij_target/)))
+ print*,'MAX/MIN TARGET LAND MASK: ',maxval(msk_target), minval(msk_target)
+
+ deallocate(work2d)
+
+!-------------------------------------------------------------------------------------
+! Read lat/lon for target grid
+!-------------------------------------------------------------------------------------
+
+ print*,"READ TARGET GRID LAT"
+ call read_vardata(indset, 'lat', lat2d)
+ allocate(rlat_target(ij_target))
+ rlat_target = reshape(lat2d,(/ij_target/))
+
+ print*,"READ TARGET GRID LON"
+ call read_vardata(indset, 'lon', lon2d)
+ allocate(rlon_target(ij_target))
+ rlon_target = reshape(lon2d,(/ij_target/))
+
+ deallocate(lat2d, lon2d)
+
+ call close_dataset(indset)
+
+!-------------------------------------------------------------------------------------
+! Calculate kgds for target grid
+!-------------------------------------------------------------------------------------
+
+ kgds_target = 0
+ call calc_kgds(i_target, j_target, kgds_target)
+
+ end subroutine read_input_data
+
+ subroutine calc_kgds(im, jm, kgds)
+!------------------------------------------------------------------
+! Create the grib 1 grid description section for a global
+! gaussian grid.
+!------------------------------------------------------------------
+
+ implicit none
+
+ integer, intent(in)               :: im, jm
+ integer, intent(inout)            :: kgds(200)
+
+ integer                           :: kscan=0, nscan=0, jm2
+ real                              :: dx, dy
+ real, parameter                   :: PI=3.14159265358979323
+
+ kgds=0
+
+ kgds(1)=4          ! oct 6, type of grid (gaussian)
+ kgds(2)=im         ! oct 7-8, # pts on latitude circle
+ jm2 = jm/2
+ kgds(3)=jm2        ! oct 9-10, # pts on longitude meridian
+ kgds(4)=90000      ! oct 11-13, lat of origin
+ kgds(5)=0          ! oct 14-16, lon of origin
+ kgds(6)=128        ! oct 17, resolution flag
+ kgds(7)=-90000     ! oct 18-20, lat of extreme point
+ dx = float(360*1000)/float(im)
+ kgds(8)=nint(dx)   ! oct 21-23, lon of extreme point
+ dy = float(jm2)
+ kgds(9)=nint(dy)   ! oct 24-25, number of circles pole to equator
+ kgds(10)=0         ! oct 26-27, not used
+ kgds(11)=kscan     ! oct 28, scanning mode flag
+ kgds(12) = nscan   ! oct 29-32, not used
+ kgds(20)=255       ! oct 5, not used
+ kgds(21) = jm      ! full number of latitude points
+
+ end subroutine calc_kgds
+
+ end module input_data

--- a/src/tref_calc.fd/input_data.f90
+++ b/src/tref_calc.fd/input_data.f90
@@ -56,8 +56,6 @@
  tref_highres = reshape(work2d,(/ij_input/))
  print*,'MAX/MIN HIGH RES TREF: ',maxval(tref_highres), minval(tref_highres)
 
- deallocate(work2d)
-
  print*,"CLOSE FILE"
  call close_dataset(indset)
  deallocate(work2d)

--- a/src/tref_calc.fd/input_data.f90
+++ b/src/tref_calc.fd/input_data.f90
@@ -149,40 +149,28 @@
 
  end subroutine read_input_data
 
- subroutine calc_kgds(im, jm, kgds)
-!------------------------------------------------------------------
-! Create the grib 1 grid description section for a global
-! gaussian grid.
-!------------------------------------------------------------------
+  subroutine calc_kgds(idim, jdim, kgds)
 
  implicit none
 
- integer, intent(in)               :: im, jm
- integer, intent(inout)            :: kgds(200)
+ integer, intent(in)  :: idim, jdim
 
- integer                           :: kscan=0, nscan=0, jm2
- real                              :: dx, dy
- real, parameter                   :: PI=3.14159265358979323
+ integer, intent(out)                 :: kgds(200)
 
- kgds=0
-
- kgds(1)=4          ! oct 6, type of grid (gaussian)
- kgds(2)=im         ! oct 7-8, # pts on latitude circle
- jm2 = jm/2
- kgds(3)=jm2        ! oct 9-10, # pts on longitude meridian
- kgds(4)=90000      ! oct 11-13, lat of origin
- kgds(5)=0          ! oct 14-16, lon of origin
- kgds(6)=128        ! oct 17, resolution flag
- kgds(7)=-90000     ! oct 18-20, lat of extreme point
- dx = float(360*1000)/float(im)
- kgds(8)=nint(dx)   ! oct 21-23, lon of extreme point
- dy = float(jm2)
- kgds(9)=nint(dy)   ! oct 24-25, number of circles pole to equator
- kgds(10)=0         ! oct 26-27, not used
- kgds(11)=kscan     ! oct 28, scanning mode flag
- kgds(12) = nscan   ! oct 29-32, not used
- kgds(20)=255       ! oct 5, not used
- kgds(21) = jm      ! full number of latitude points
+ kgds     = 0
+ kgds(1)  = 4                       ! OCT 6 - TYPE OF GRID (GAUSSIAN)
+ kgds(2)  = idim                    ! OCT 7-8 - # PTS ON LATITUDE CIRCLE
+ kgds(3)  = jdim                    ! OCT 9-10 - # PTS ON LONGITUDE CIRCLE
+ kgds(4)  = 90000                   ! OCT 11-13 - LAT OF ORIGIN
+ kgds(5)  = 0                       ! OCT 14-16 - LON OF ORIGIN
+ kgds(6)  = 128                     ! OCT 17 - RESOLUTION FLAG
+ kgds(7)  = -90000                  ! OCT 18-20 - LAT OF EXTREME POINT
+ kgds(8)  = nint(-360000./idim)     ! OCT 21-23 - LON OF EXTREME POINT
+ kgds(9)  = nint((360.0 / float(idim))*1000.0)
+                                          ! OCT 24-25 - LONGITUDE DIRECTION INCR.
+ kgds(10) = jdim/2                  ! OCT 26-27 - NUMBER OF CIRCLES POLE TO EQUATOR
+ kgds(12) = 255                     ! OCT 29 - RESERVED
+ kgds(20) = 255                     ! OCT 5  - NOT USED, SET TO 255
 
  end subroutine calc_kgds
 

--- a/src/tref_calc.fd/input_data.f90
+++ b/src/tref_calc.fd/input_data.f90
@@ -30,11 +30,9 @@
 
  implicit none
 
- integer :: vlev,rvlev
  type(Dataset) :: indset
  type(Dimension) :: ncdim
  real, allocatable                            :: work2d(:,:)
- integer iret
 
  print*
  print*,"OPEN INPUT FILE: ",trim(sfcanl_file)

--- a/src/tref_calc.fd/input_data.f90
+++ b/src/tref_calc.fd/input_data.f90
@@ -45,7 +45,7 @@
 
  ij_input = i_input * j_input
 
-  print*
+ print*
  print*,"READ TREF FROM input FILE"
  call read_vardata(indset, 'tref', work2d)
 

--- a/src/tref_calc.fd/input_data.f90
+++ b/src/tref_calc.fd/input_data.f90
@@ -1,5 +1,6 @@
  module input_data
 
+ use utils
  use setup
  use module_ncio
 
@@ -7,16 +8,15 @@
 
  private
 
- real, allocatable, public                    :: tref_source(:)
- real, allocatable, public                    :: tref_target(:)
- real, allocatable, public                    :: rlat_source(:)
- real, allocatable, public                    :: rlon_source(:)
- real, allocatable, public                    :: rlat_target(:)
- real, allocatable, public                    :: rlon_target(:)
- integer, allocatable, public                 :: msk_target(:)
+ integer, public                              :: ij_input, kgds_input(200)
+ integer, public                              :: i_input, j_input
 
- integer, public                              :: kgds_source(200)
- integer, public                              :: kgds_target(200)
+
+ real, allocatable, public                    :: tref_highres(:)
+ real, allocatable, public                    :: tref_lowres(:)
+ integer, allocatable, public                 :: slmsk_lowres(:)
+
+ real  :: missing_value=1.e30
 
  public                                       :: read_input_data
 
@@ -25,66 +25,48 @@
  subroutine read_input_data
 
 !-------------------------------------------------------------------------------------
-! Read tref from sfcanl.nc and sfcf006.nc
+! Read input grid data from a netcdf file.
 !-------------------------------------------------------------------------------------
 
  implicit none
 
+ integer :: vlev,rvlev
  type(Dataset) :: indset
  type(Dimension) :: ncdim
  real, allocatable                            :: work2d(:,:)
- real, allocatable                            :: lat2d(:,:), lon2d(:,:)
-
-!-------------------------------------------------------------------------------------
-! Read source file (sfcanl.nc)
-!-------------------------------------------------------------------------------------
+ integer iret
 
  print*
- print*,"OPEN SOURCE FILE: ",trim(sfcanl_file)
+ print*,"OPEN INPUT FILE: ",trim(sfcanl_file)
  indset = open_dataset(sfcanl_file)
 
- print*,"GET SOURCE FILE HEADER"
- ncdim = get_dim(indset, 'grid_xt'); i_source = ncdim%len
- ncdim = get_dim(indset, 'grid_yt'); j_source = ncdim%len
+ print*,"GET INPUT FILE HEADER"
+ ncdim = get_dim(indset, 'grid_xt'); i_input = ncdim%len
+ ncdim = get_dim(indset, 'grid_yt'); j_input = ncdim%len
 
- print*,'DIMENSIONS OF SOURCE DATA ARE: ', i_source, j_source
+ print*,'DIMENSIONS OF DATA ARE: ', i_input, j_input
 
- ij_source = i_source * j_source
+ ij_input = i_input * j_input
 
- print*
- print*,"READ TREF FROM SOURCE FILE"
+  print*
+ print*,"READ TREF FROM input FILE"
  call read_vardata(indset, 'tref', work2d)
 
- allocate(tref_source(ij_source))
- tref_source = reshape(work2d,(/ij_source/))
- print*,'MAX/MIN SOURCE TREF: ',maxval(tref_source), minval(tref_source)
+ allocate(tref_highres(ij_input))
+ tref_highres = reshape(work2d,(/ij_input/))
+ print*,'MAX/MIN HIGH RES TREF: ',maxval(tref_highres), minval(tref_highres)
 
  deallocate(work2d)
 
-!-------------------------------------------------------------------------------------
-! Read lat/lon for source grid
-!-------------------------------------------------------------------------------------
-
- print*,"READ SOURCE GRID LAT"
- call read_vardata(indset, 'lat', lat2d)
- allocate(rlat_source(ij_source))
- rlat_source = reshape(lat2d,(/ij_source/))
-
- print*,"READ SOURCE GRID LON"
- call read_vardata(indset, 'lon', lon2d)
- allocate(rlon_source(ij_source))
- rlon_source = reshape(lon2d,(/ij_source/))
-
- deallocate(lat2d, lon2d)
-
+ print*,"CLOSE FILE"
  call close_dataset(indset)
+ deallocate(work2d)
 
-!-------------------------------------------------------------------------------------
-! Calculate kgds for source grid
-!-------------------------------------------------------------------------------------
+!---------------------------------------------------------------------------------------
+! Set the grib 1 grid description array need by the NCEP IPOLATES library.
+!---------------------------------------------------------------------------------------
 
- kgds_source = 0
- call calc_kgds(i_source, j_source, kgds_source)
+ call calc_kgds(i_input, j_input, kgds_input)
 
 !-------------------------------------------------------------------------------------
 ! Read target file (sfcf006.nc)
@@ -95,20 +77,20 @@
  indset = open_dataset(sfcf006_file)
 
  print*,"GET TARGET FILE HEADER"
- ncdim = get_dim(indset, 'grid_xt'); i_target = ncdim%len
- ncdim = get_dim(indset, 'grid_yt'); j_target = ncdim%len
+ ncdim = get_dim(indset, 'grid_xt'); i_output = ncdim%len
+ ncdim = get_dim(indset, 'grid_yt'); j_output = ncdim%len
 
- print*,'DIMENSIONS OF TARGET DATA ARE: ', i_target, j_target
+ print*,'DIMENSIONS OF TARGET DATA ARE: ', i_output, j_output
 
- ij_target = i_target * j_target
+ ij_output = i_output * j_output
 
  print*
  print*,"READ TREF FROM TARGET FILE"
  call read_vardata(indset, 'tref', work2d)
 
- allocate(tref_target(ij_target))
- tref_target = reshape(work2d,(/ij_target/))
- print*,'MAX/MIN TARGET TREF: ',maxval(tref_target), minval(tref_target)
+ allocate(tref_lowres(ij_output))
+ tref_lowres = reshape(work2d,(/ij_output/))
+ print*,'MAX/MIN TARGET TREF: ',maxval(tref_lowres), minval(tref_lowres)
 
  deallocate(work2d)
 
@@ -116,62 +98,14 @@
  print*,"READ LAND MASK FROM TARGET FILE"
  call read_vardata(indset, 'land', work2d)
 
- allocate(msk_target(ij_target))
- msk_target = nint(reshape(work2d,(/ij_target/)))
- print*,'MAX/MIN TARGET LAND MASK: ',maxval(msk_target), minval(msk_target)
+ allocate(slmsk_lowres(ij_output))
+ slmsk_lowres = nint(reshape(work2d,(/ij_output/)))
+ print*,'MAX/MIN TARGET LAND MASK: ',maxval(slmsk_lowres), minval(slmsk_lowres)
 
  deallocate(work2d)
 
-!-------------------------------------------------------------------------------------
-! Read lat/lon for target grid
-!-------------------------------------------------------------------------------------
-
- print*,"READ TARGET GRID LAT"
- call read_vardata(indset, 'lat', lat2d)
- allocate(rlat_target(ij_target))
- rlat_target = reshape(lat2d,(/ij_target/))
-
- print*,"READ TARGET GRID LON"
- call read_vardata(indset, 'lon', lon2d)
- allocate(rlon_target(ij_target))
- rlon_target = reshape(lon2d,(/ij_target/))
-
- deallocate(lat2d, lon2d)
-
- call close_dataset(indset)
-
-!-------------------------------------------------------------------------------------
-! Calculate kgds for target grid
-!-------------------------------------------------------------------------------------
-
- kgds_target = 0
- call calc_kgds(i_target, j_target, kgds_target)
+ return
 
  end subroutine read_input_data
-
-  subroutine calc_kgds(idim, jdim, kgds)
-
- implicit none
-
- integer, intent(in)  :: idim, jdim
-
- integer, intent(out)                 :: kgds(200)
-
- kgds     = 0
- kgds(1)  = 4                       ! OCT 6 - TYPE OF GRID (GAUSSIAN)
- kgds(2)  = idim                    ! OCT 7-8 - # PTS ON LATITUDE CIRCLE
- kgds(3)  = jdim                    ! OCT 9-10 - # PTS ON LONGITUDE CIRCLE
- kgds(4)  = 90000                   ! OCT 11-13 - LAT OF ORIGIN
- kgds(5)  = 0                       ! OCT 14-16 - LON OF ORIGIN
- kgds(6)  = 128                     ! OCT 17 - RESOLUTION FLAG
- kgds(7)  = -90000                  ! OCT 18-20 - LAT OF EXTREME POINT
- kgds(8)  = nint(-360000./idim)     ! OCT 21-23 - LON OF EXTREME POINT
- kgds(9)  = nint((360.0 / float(idim))*1000.0)
-                                          ! OCT 24-25 - LONGITUDE DIRECTION INCR.
- kgds(10) = jdim/2                  ! OCT 26-27 - NUMBER OF CIRCLES POLE TO EQUATOR
- kgds(12) = 255                     ! OCT 29 - RESERVED
- kgds(20) = 255                     ! OCT 5  - NOT USED, SET TO 255
-
- end subroutine calc_kgds
 
  end module input_data

--- a/src/tref_calc.fd/input_data.f90
+++ b/src/tref_calc.fd/input_data.f90
@@ -16,7 +16,6 @@
  real, allocatable, public                    :: tref_lowres(:)
  integer, allocatable, public                 :: slmsk_lowres(:)
 
- real  :: missing_value=1.e30
 
  public                                       :: read_input_data
 

--- a/src/tref_calc.fd/interp.F90
+++ b/src/tref_calc.fd/interp.F90
@@ -51,8 +51,6 @@
    allocate(tref_interp(ij_output))
    tref_interp = tref_highres
    
-   ! Set values to 0 where absolute value is greater than 1
-   where (abs(tref_interp) > 1.0) tref_interp = 0.0
    
    deallocate(tref_highres)
 
@@ -107,8 +105,6 @@
  allocate(tref_interp(ij_output))
  tref_interp = data_output(:,num_fields) - tref_lowres(:)
  
- ! Set values to 0 where absolute value is greater than 1
- where (abs(tref_interp) > 1.0) tref_interp = 0.0
 
  deallocate (ibi, ibo, bitmap_input, bitmap_output)
 

--- a/src/tref_calc.fd/interp.F90
+++ b/src/tref_calc.fd/interp.F90
@@ -1,0 +1,123 @@
+ module interp
+
+ implicit none
+
+ private
+
+ real, allocatable, public      :: dtf(:)
+
+ public                         :: interpolate_to_target
+
+ contains
+
+ subroutine interpolate_to_target
+
+!---------------------------------------------------------------------------------
+! Interpolate tref from source grid to target grid and compute difference
+!---------------------------------------------------------------------------------
+
+ use input_data
+ use setup
+
+ implicit none
+
+ integer                       :: iret
+ integer                       :: ip, ipopt(20)
+ integer                       :: km, count_target
+ integer                       :: no, ij_target
+ logical*1, allocatable        :: bitmap_source(:), bitmap_target(:)
+ real, allocatable             :: tref_source_interp(:)
+ real, allocatable             :: rlat_target_deg(:), rlon_target_deg(:)
+ real, allocatable             :: rlat_source_deg(:), rlon_source_deg(:)
+
+!---------------------------------------------------------------------------------
+! Set up interpolation
+!---------------------------------------------------------------------------------
+
+ ip = 0        ! bilinear interpolation
+ ipopt = 0
+
+ km = 1        ! number of fields to interpolate (just tref)
+ no = ij_target
+
+!---------------------------------------------------------------------------------
+! Set up bitmaps (no missing values)
+!---------------------------------------------------------------------------------
+
+ allocate(bitmap_source(ij_source))
+ bitmap_source = .true.
+
+ allocate(bitmap_target(ij_target))
+ bitmap_target = .false.
+
+!---------------------------------------------------------------------------------
+! Allocate array for interpolated source tref
+!---------------------------------------------------------------------------------
+
+ allocate(tref_source_interp(ij_target))
+ tref_source_interp = 0.0
+
+!---------------------------------------------------------------------------------
+! Convert lat/lon from radians to degrees if necessary
+! (module_ncio typically returns degrees, but check)
+!---------------------------------------------------------------------------------
+
+ allocate(rlat_source_deg(ij_source))
+ allocate(rlon_source_deg(ij_source))
+ allocate(rlat_target_deg(ij_target))
+ allocate(rlon_target_deg(ij_target))
+
+ rlat_source_deg = rlat_source
+ rlon_source_deg = rlon_source
+ rlat_target_deg = rlat_target
+ rlon_target_deg = rlon_target
+
+!---------------------------------------------------------------------------------
+! Perform interpolation using IPOLATES
+!---------------------------------------------------------------------------------
+
+#ifdef IP_V4
+ print*,"INTERPOLATE TREF FROM SOURCE TO TARGET GRID USING IPOLATES (V4)"
+ call ipolates(ip, ipopt, kgds_source, kgds_target, &
+               ij_source, ij_target, km, &
+               bitmap_source, tref_source, &
+               no, rlat_target_deg, rlon_target_deg, &
+               tref_source_interp, iret)
+#else
+ print*,"INTERPOLATE TREF FROM SOURCE TO TARGET GRID USING IPOLATES"
+ call ipolates(ip, ipopt, kgds_source, kgds_target, &
+               ij_source, ij_target, km, &
+               bitmap_source, tref_source, &
+               count_target, &
+               rlat_target_deg, rlon_target_deg, &
+               bitmap_target, tref_source_interp, iret)
+#endif
+
+ if (iret /= 0) then
+   print*,"FATAL ERROR IN IPOLATES. IRET IS: ", iret
+   stop
+ endif
+
+ print*,'MAX/MIN INTERPOLATED SOURCE TREF: ',maxval(tref_source_interp), minval(tref_source_interp)
+
+!---------------------------------------------------------------------------------
+! Compute difference: dtf = tref_source_interp - tref_target
+!---------------------------------------------------------------------------------
+
+ allocate(dtf(ij_target))
+ dtf = tref_source_interp - tref_target
+
+ print*,'MAX/MIN DTF: ',maxval(dtf), minval(dtf)
+
+!---------------------------------------------------------------------------------
+! Clean up
+!---------------------------------------------------------------------------------
+
+ deallocate(bitmap_source, bitmap_target)
+ deallocate(tref_source_interp)
+ deallocate(rlat_source_deg, rlon_source_deg)
+ deallocate(rlat_target_deg, rlon_target_deg)
+
+ end subroutine interpolate_to_target
+
+ end module interp

--- a/src/tref_calc.fd/interp.F90
+++ b/src/tref_calc.fd/interp.F90
@@ -22,7 +22,7 @@
 
  implicit none
 
- integer                       :: iret
+ integer                       :: iret, numpts
  integer                       :: ip, ipopt(20)
  integer                       :: num_fields
  integer, allocatable          :: ibi(:), ibo(:)
@@ -55,7 +55,8 @@
  bitmap_output = .true.
 
  allocate(data_input(ij_source,num_fields))
- data_input(:,1) = tref_source
+ data_input(:,1) = tref_source(:)
+ deallocate(tref_source)
 
  allocate(data_output(ij_target,num_fields))
  data_output = 0.0
@@ -81,7 +82,7 @@
 !---------------------------------------------------------------------------------
  call ipolates(ip, ipopt, kgds_source, kgds_target, ij_source, ij_target, &
                num_fields, ibi, bitmap_input, data_input, &
-               ij_target, rlat_output, rlon_output, ibo, bitmap_output, &
+               numpts, rlat_output, rlon_output, ibo, bitmap_output, &
                data_output, iret)
 
  if (iret /= 0) then

--- a/src/tref_calc.fd/interp.F90
+++ b/src/tref_calc.fd/interp.F90
@@ -18,7 +18,7 @@
  use input_data
  use setup
 #ifdef IP_V4
- use ip_mod, only: ipolates, ipolatev
+ use ip_mod, only: ipolates
 #endif
 
  implicit none
@@ -100,7 +100,10 @@
                num_fields, ibi, bitmap_input, data_input,  &
                numpts, rlat_output, rlon_output, ibo, bitmap_output, &
                data_output, iret)
- if (iret /= 0) goto 89
+ if (iret /= 0)
+   print*,"FATAL ERROR IN IPOLATES. IRET IS: ", iret
+   call errexit(23)
+ end if 
 
  allocate(tref_interp(ij_output))
  tref_interp = data_output(:,num_fields) - tref_lowres(:)
@@ -111,10 +114,6 @@
  endif
 
  return
-
- 89 continue
- print*,"FATAL ERROR IN IPOLATES. IRET IS: ", iret
- call errexit(23)
 
  end subroutine gaus_to_gaus
 

--- a/src/tref_calc.fd/interp.F90
+++ b/src/tref_calc.fd/interp.F90
@@ -32,7 +32,7 @@
  logical                 :: same_grid
 
  real, allocatable       :: data_input(:,:)
- real, allocatable       :: data_output(:,:), crot(:), srot(:)
+ real, allocatable       :: data_output(:,:)
 
  same_grid=.true.
  do i = 1, 11

--- a/src/tref_calc.fd/interp.F90
+++ b/src/tref_calc.fd/interp.F90
@@ -36,80 +36,80 @@
 
  same_grid=.true.
  do i = 1, 11
-   if (kgds_input(i) /= kgds_output(i)) then
-     same_grid=.false.
-     exit
-   endif
+  if (kgds_input(i) /= kgds_output(i)) then
+    same_grid=.false.
+    exit
+  endif
  enddo
 
  if (same_grid) then
 
-   print*
-   print*,'INPUT AND OUTPUT GRIDS ARE THE SAME.'
-   print*,'NO HORIZ INTERPOLATION REQUIRED.'
+    print*
+    print*,'INPUT AND OUTPUT GRIDS ARE THE SAME.'
+    print*,'NO HORIZ INTERPOLATION REQUIRED.'
 
-   allocate(tref_interp(ij_output))
-   tref_interp = tref_highres
-   
-   
-   deallocate(tref_highres)
+    allocate(tref_interp(ij_output))
+    tref_interp = tref_highres
+    
+    
+    deallocate(tref_highres)
 
- else
+  else
 
-   print*
-   print*,'INTERPOLATE DATA TO OUTPUT GRID'
+    print*
+    print*,'INTERPOLATE DATA TO OUTPUT GRID'
 
 
- ip    = 0   ! bilinear
- ipopt = 0
+    ip    = 0   ! bilinear
+    ipopt = 0
 
-!----------------------------------------------------------------------------------
-! Do 2-D fields first
-!----------------------------------------------------------------------------------
+    !----------------------------------------------------------------------------------
+    ! Do 2-D fields first
+    !----------------------------------------------------------------------------------
 
- num_fields = 1
+    num_fields = 1
 
- allocate(ibi(num_fields))
- ibi = 0 ! no bitmap
- allocate(ibo(num_fields))
- ibo = 0 ! no bitmap
+    allocate(ibi(num_fields))
+    ibi = 0 ! no bitmap
+    allocate(ibo(num_fields))
+    ibo = 0 ! no bitmap
 
- allocate(bitmap_input(ij_input,num_fields))
- bitmap_input = .true.
- allocate(bitmap_output(ij_output,num_fields))
- bitmap_output = .true.
+    allocate(bitmap_input(ij_input,num_fields))
+    bitmap_input = .true.
+    allocate(bitmap_output(ij_output,num_fields))
+    bitmap_output = .true.
 
- allocate(rlat_output(ij_output))
- rlat_output = 0.0
- allocate(rlon_output(ij_output))
- rlon_output = 0.0
+    allocate(rlat_output(ij_output))
+    rlat_output = 0.0
+    allocate(rlon_output(ij_output))
+    rlon_output = 0.0
 
-!----------------
-! Tref
-!----------------
+    !----------------
+    ! Tref
+    !----------------
 
- allocate(data_input(ij_input,num_fields))
- data_input(:,num_fields) = tref_highres(:)
- deallocate(tref_highres)
+    allocate(data_input(ij_input,num_fields))
+    data_input(:,num_fields) = tref_highres(:)
+    deallocate(tref_highres)
 
- allocate(data_output(ij_output,num_fields))
- data_output = 0
+    allocate(data_output(ij_output,num_fields))
+    data_output = 0
 
- print*,"INTERPOLATE TREF"
- call ipolates(ip, ipopt, kgds_input, kgds_output, ij_input, ij_output,&
-               num_fields, ibi, bitmap_input, data_input,  &
-               numpts, rlat_output, rlon_output, ibo, bitmap_output, &
-               data_output, iret)
- if (iret /= 0)
-   print*,"FATAL ERROR IN IPOLATES. IRET IS: ", iret
-   call errexit(23)
- end if 
+    print*,"INTERPOLATE TREF"
+    call ipolates(ip, ipopt, kgds_input, kgds_output, ij_input, ij_output,&
+                  num_fields, ibi, bitmap_input, data_input,  &
+                  numpts, rlat_output, rlon_output, ibo, bitmap_output, &
+                  data_output, iret)
+    if (iret /= 0) then
+      print*,"FATAL ERROR IN IPOLATES. IRET IS: ", iret
+      call errexit(23)
+    endif
 
- allocate(tref_interp(ij_output))
- tref_interp = data_output(:,num_fields) - tref_lowres(:)
- 
+    allocate(tref_interp(ij_output))
+    tref_interp = data_output(:,num_fields) - tref_lowres(:)
 
- deallocate (ibi, ibo, bitmap_input, bitmap_output)
+
+    deallocate (ibi, ibo, bitmap_input, bitmap_output)
 
  endif
 

--- a/src/tref_calc.fd/interp.F90
+++ b/src/tref_calc.fd/interp.F90
@@ -4,117 +4,115 @@
 
  private
 
- real, allocatable, public      :: dtf(:)
-
- public                         :: interpolate_to_target
+ public                 :: gaus_to_gaus
 
  contains
 
- subroutine interpolate_to_target
+ subroutine gaus_to_gaus
 
-!---------------------------------------------------------------------------------
-! Interpolate tref from source grid to target grid and compute difference
-!---------------------------------------------------------------------------------
+!----------------------------------------------------------------------------------
+! Interpolate data from the input to output grid using IPOLATES library.
+!----------------------------------------------------------------------------------
 
+ use output_data
  use input_data
  use setup
- use ip_mod, only: ipolates
+#ifdef IP_V4
+ use ip_mod, only: ipolates, ipolatev
+#endif
 
  implicit none
 
- integer                       :: iret, numpts
- integer                       :: ip, ipopt(20)
- integer                       :: num_fields
- integer, allocatable          :: ibi(:), ibo(:)
- logical*1, allocatable        :: bitmap_input(:,:), bitmap_output(:,:)
- real, allocatable             :: tref_source_interp(:)
- real, allocatable             :: data_input(:,:), data_output(:,:)
- real, allocatable             :: rlat_output(:), rlon_output(:)
- real, allocatable             :: rlat_target_deg(:), rlon_target_deg(:)
+ integer                 :: ip, ipopt(20), i
+ integer                 :: num_fields
+ integer                 :: iret, numpts
+ integer, allocatable    :: ibi(:), ibo(:)
 
-!---------------------------------------------------------------------------------
-! Set up interpolation
-!---------------------------------------------------------------------------------
+ logical*1, allocatable  :: bitmap_input(:,:), bitmap_output(:,:)
+ logical                 :: same_grid
 
- ip = 0        ! bilinear interpolation
+ real, allocatable       :: data_input(:,:)
+ real, allocatable       :: data_output(:,:), crot(:), srot(:)
+
+ same_grid=.true.
+ do i = 1, 11
+   if (kgds_input(i) /= kgds_output(i)) then
+     same_grid=.false.
+     exit
+   endif
+ enddo
+
+ if (same_grid) then
+
+   print*
+   print*,'INPUT AND OUTPUT GRIDS ARE THE SAME.'
+   print*,'NO HORIZ INTERPOLATION REQUIRED.'
+
+   allocate(tref_interp(ij_output))
+   tref_interp = tref_highres
+   deallocate(tref_highres)
+
+ else
+
+   print*
+   print*,'INTERPOLATE DATA TO OUTPUT GRID'
+
+
+ ip    = 0   ! bilinear
  ipopt = 0
 
- num_fields = 1        ! number of fields to interpolate (just tref)
+!----------------------------------------------------------------------------------
+! Do 2-D fields first
+!----------------------------------------------------------------------------------
 
-!---------------------------------------------------------------------------------
-! Set up bitmaps and input/output arrays (no missing values)
-!---------------------------------------------------------------------------------
+ num_fields = 1
 
  allocate(ibi(num_fields))
  ibi = 0 ! no bitmap
  allocate(ibo(num_fields))
  ibo = 0 ! no bitmap
- allocate(bitmap_input(ij_source,num_fields))
+
+ allocate(bitmap_input(ij_input,num_fields))
  bitmap_input = .true.
- allocate(bitmap_output(ij_target,num_fields))
+ allocate(bitmap_output(ij_output,num_fields))
  bitmap_output = .true.
 
- allocate(data_input(ij_source,num_fields))
- data_input(:,1) = tref_source(:)
- deallocate(tref_source)
-
- allocate(data_output(ij_target,num_fields))
- data_output = 0.0
-
-!---------------------------------------------------------------------------------
-! Allocate array for interpolated source tref
-!---------------------------------------------------------------------------------
-
- allocate(tref_source_interp(ij_target))
- tref_source_interp = 0.0
-
-!---------------------------------------------------------------------------------
-! Allocate lat/lon arrays
-!---------------------------------------------------------------------------------
-
- allocate(rlat_output(ij_target))
+ allocate(rlat_output(ij_output))
  rlat_output = 0.0
- allocate(rlon_output(ij_target))
+ allocate(rlon_output(ij_output))
  rlon_output = 0.0
 
-!---------------------------------------------------------------------------------
-! Perform interpolation using IPOLATES
-!---------------------------------------------------------------------------------
- call ipolates(ip, ipopt, kgds_source, kgds_target, ij_source, ij_target, &
-               num_fields, ibi, bitmap_input, data_input, &
+!----------------
+! Tref
+!----------------
+
+ allocate(data_input(ij_input,num_fields))
+ data_input(:,num_fields) = tref_highres(:)
+ deallocate(tref_highres)
+
+ allocate(data_output(ij_output,num_fields))
+ data_output = 0
+
+ print*,"INTERPOLATE TREF"
+ call ipolates(ip, ipopt, kgds_input, kgds_output, ij_input, ij_output,&
+               num_fields, ibi, bitmap_input, data_input,  &
                numpts, rlat_output, rlon_output, ibo, bitmap_output, &
                data_output, iret)
+ if (iret /= 0) goto 89
 
- if (iret /= 0) then
-   print*,"FATAL ERROR IN IPOLATES. IRET IS: ", iret
-   stop
+ allocate(tref_interp(ij_output))
+ tref_interp = data_output(:,num_fields)
+
+ deallocate (ibi, ibo, bitmap_input, bitmap_output)
+
  endif
 
+ return
 
- if (iret == 0) then
-   tref_source_interp = data_output(:,num_fields)
- endif
- print*,'MAX/MIN INTERPOLATED SOURCE TREF: ',maxval(tref_source_interp), minval(tref_source_interp)
+ 89 continue
+ print*,"FATAL ERROR IN IPOLATES. IRET IS: ", iret
+ call errexit(23)
 
-!---------------------------------------------------------------------------------
-! Compute difference: dtf = tref_source_interp - tref_target
-!---------------------------------------------------------------------------------
-
- allocate(dtf(ij_target))
- dtf = tref_source_interp - tref_target
-
- print*,'MAX/MIN DTF: ',maxval(dtf), minval(dtf)
-
-!---------------------------------------------------------------------------------
-! Clean up
-!---------------------------------------------------------------------------------
-
- deallocate(ibi, ibo)
- deallocate(bitmap_input, bitmap_output)
- deallocate(data_input, data_output)
- deallocate(tref_source_interp)
- deallocate(rlat_output, rlon_output)
-
- end subroutine interpolate_to_target
+ end subroutine gaus_to_gaus
 
  end module interp

--- a/src/tref_calc.fd/interp.F90
+++ b/src/tref_calc.fd/interp.F90
@@ -50,6 +50,10 @@
 
    allocate(tref_interp(ij_output))
    tref_interp = tref_highres
+   
+   ! Set values to 0 where absolute value is greater than 1
+   where (abs(tref_interp) > 1.0) tref_interp = 0.0
+   
    deallocate(tref_highres)
 
  else
@@ -101,7 +105,10 @@
  if (iret /= 0) goto 89
 
  allocate(tref_interp(ij_output))
- tref_interp = data_output(:,num_fields)
+ tref_interp = data_output(:,num_fields) - tref_lowres(:)
+ 
+ ! Set values to 0 where absolute value is greater than 1
+ where (abs(tref_interp) > 1.0) tref_interp = 0.0
 
  deallocate (ibi, ibo, bitmap_input, bitmap_output)
 

--- a/src/tref_calc.fd/interp.F90
+++ b/src/tref_calc.fd/interp.F90
@@ -18,17 +18,19 @@
 
  use input_data
  use setup
+ use ip_mod, only: ipolates
 
  implicit none
 
  integer                       :: iret
  integer                       :: ip, ipopt(20)
- integer                       :: km, count_target
- integer                       :: no, ij_target
- logical*1, allocatable        :: bitmap_source(:), bitmap_target(:)
+ integer                       :: num_fields
+ integer, allocatable          :: ibi(:), ibo(:)
+ logical*1, allocatable        :: bitmap_input(:,:), bitmap_output(:,:)
  real, allocatable             :: tref_source_interp(:)
+ real, allocatable             :: data_input(:,:), data_output(:,:)
+ real, allocatable             :: rlat_output(:), rlon_output(:)
  real, allocatable             :: rlat_target_deg(:), rlon_target_deg(:)
- real, allocatable             :: rlat_source_deg(:), rlon_source_deg(:)
 
 !---------------------------------------------------------------------------------
 ! Set up interpolation
@@ -37,18 +39,26 @@
  ip = 0        ! bilinear interpolation
  ipopt = 0
 
- km = 1        ! number of fields to interpolate (just tref)
- no = ij_target
+ num_fields = 1        ! number of fields to interpolate (just tref)
 
 !---------------------------------------------------------------------------------
-! Set up bitmaps (no missing values)
+! Set up bitmaps and input/output arrays (no missing values)
 !---------------------------------------------------------------------------------
 
- allocate(bitmap_source(ij_source))
- bitmap_source = .true.
+ allocate(ibi(num_fields))
+ ibi = 0 ! no bitmap
+ allocate(ibo(num_fields))
+ ibo = 0 ! no bitmap
+ allocate(bitmap_input(ij_source,num_fields))
+ bitmap_input = .true.
+ allocate(bitmap_output(ij_target,num_fields))
+ bitmap_output = .true.
 
- allocate(bitmap_target(ij_target))
- bitmap_target = .false.
+ allocate(data_input(ij_source,num_fields))
+ data_input(:,1) = tref_source
+
+ allocate(data_output(ij_target,num_fields))
+ data_output = 0.0
 
 !---------------------------------------------------------------------------------
 ! Allocate array for interpolated source tref
@@ -58,46 +68,31 @@
  tref_source_interp = 0.0
 
 !---------------------------------------------------------------------------------
-! Convert lat/lon from radians to degrees if necessary
-! (module_ncio typically returns degrees, but check)
+! Allocate lat/lon arrays
 !---------------------------------------------------------------------------------
 
- allocate(rlat_source_deg(ij_source))
- allocate(rlon_source_deg(ij_source))
- allocate(rlat_target_deg(ij_target))
- allocate(rlon_target_deg(ij_target))
-
- rlat_source_deg = rlat_source
- rlon_source_deg = rlon_source
- rlat_target_deg = rlat_target
- rlon_target_deg = rlon_target
+ allocate(rlat_output(ij_target))
+ rlat_output = 0.0
+ allocate(rlon_output(ij_target))
+ rlon_output = 0.0
 
 !---------------------------------------------------------------------------------
 ! Perform interpolation using IPOLATES
 !---------------------------------------------------------------------------------
-
-#ifdef IP_V4
- print*,"INTERPOLATE TREF FROM SOURCE TO TARGET GRID USING IPOLATES (V4)"
- call ipolates(ip, ipopt, kgds_source, kgds_target, &
-               ij_source, ij_target, km, &
-               bitmap_source, tref_source, &
-               no, rlat_target_deg, rlon_target_deg, &
-               tref_source_interp, iret)
-#else
- print*,"INTERPOLATE TREF FROM SOURCE TO TARGET GRID USING IPOLATES"
- call ipolates(ip, ipopt, kgds_source, kgds_target, &
-               ij_source, ij_target, km, &
-               bitmap_source, tref_source, &
-               count_target, &
-               rlat_target_deg, rlon_target_deg, &
-               bitmap_target, tref_source_interp, iret)
-#endif
+ call ipolates(ip, ipopt, kgds_source, kgds_target, ij_source, ij_target, &
+               num_fields, ibi, bitmap_input, data_input, &
+               ij_target, rlat_output, rlon_output, ibo, bitmap_output, &
+               data_output, iret)
 
  if (iret /= 0) then
    print*,"FATAL ERROR IN IPOLATES. IRET IS: ", iret
    stop
  endif
 
+
+ if (iret == 0) then
+   tref_source_interp = data_output(:,num_fields)
+ endif
  print*,'MAX/MIN INTERPOLATED SOURCE TREF: ',maxval(tref_source_interp), minval(tref_source_interp)
 
 !---------------------------------------------------------------------------------
@@ -113,10 +108,11 @@
 ! Clean up
 !---------------------------------------------------------------------------------
 
- deallocate(bitmap_source, bitmap_target)
+ deallocate(ibi, ibo)
+ deallocate(bitmap_input, bitmap_output)
+ deallocate(data_input, data_output)
  deallocate(tref_source_interp)
- deallocate(rlat_source_deg, rlon_source_deg)
- deallocate(rlat_target_deg, rlon_target_deg)
+ deallocate(rlat_output, rlon_output)
 
  end subroutine interpolate_to_target
 

--- a/src/tref_calc.fd/output_data.f90
+++ b/src/tref_calc.fd/output_data.f90
@@ -62,6 +62,7 @@
  integer, dimension(2)             :: start, count, dimids
  real, allocatable                 :: out2d(:,:), out2dflip(:,:)
  integer, allocatable              :: msk2d(:,:), msk2dflip(:,:)
+ integer(1), allocatable           :: mskbyte(:,:)
  real, allocatable                 :: lat_extended(:)
  integer                           :: j_extended
  integer                           :: iflip, iret
@@ -169,7 +170,7 @@
 
  print*,"WRITE LON"
  out2d = reshape(rlon_output, (/i_output,j_output/))
- iret = nf90_put_var(ncid, lon_varid, out2d(1,j_output:1:-1))
+ iret = nf90_put_var(ncid, lon_varid, out2d(:,1))
  if (iret /= nf90_noerr) stop 'ERROR writing lon'
 
 !-------------------------------------------------------------------
@@ -199,15 +200,18 @@
  allocate(msk2d(i_output,j_extended),msk2dflip(i_output,j_extended))
  
 ! Fill with dummy value (0) at poles
- msk2d(:,1) = 1
+ msk2d(:,1) = 2
  msk2d(:,2:j_output+1) = reshape(slmsk_lowres, (/i_output,j_output/))
  msk2d(:,j_extended) = 1
  
  do iflip=1,i_output
    msk2dflip(iflip,:) = msk2d(iflip, j_extended:1:-1)
  enddo
+ 
+ allocate(mskbyte(i_output, j_extended))
+ mskbyte = int(msk2dflip, kind=1)
 
- iret = nf90_put_var(ncid, msk_varid, int(msk2dflip, kind=1), start, count)
+ iret = nf90_put_var(ncid, msk_varid, mskbyte, start, count)
  if (iret /= nf90_noerr) stop 'ERROR writing msk'
 
 !-------------------------------------------------------------------

--- a/src/tref_calc.fd/output_data.f90
+++ b/src/tref_calc.fd/output_data.f90
@@ -4,9 +4,44 @@
 
  private
 
+ integer, public                   :: kgds_output(200)
+
+! data on the output grid.
+ real, allocatable, public         :: tref_interp(:)
+ real, allocatable, public         :: rlat_output(:)
+ real, allocatable, public         :: rlon_output(:)
+
+ public                            :: set_output_grid
  public                            :: write_output_data
 
  contains
+
+ subroutine set_output_grid
+
+!-------------------------------------------------------------------
+! Set grid specs on the output grid.
+!-------------------------------------------------------------------
+
+ use setup
+ use input_data
+ use utils
+
+ implicit none
+
+
+ print*
+ print*,"OUTPUT GRID I/J DIMENSIONS: ", i_output, j_output
+
+!-------------------------------------------------------------------
+! Set the grib 1 grid description section, which is needed
+! by the IPOLATES library.
+!-------------------------------------------------------------------
+
+ kgds_output = 0
+
+ call calc_kgds(i_output, j_output, kgds_output)
+
+ end subroutine set_output_grid
 
  subroutine write_output_data
 
@@ -17,7 +52,6 @@
  use netcdf
  use input_data
  use setup
- use interp
 
  implicit none
 
@@ -57,15 +91,15 @@
  endif
 
 !-------------------------------------------------------------------
-! Define dimensions (add 2 to j_target for poles at -90 and 90)
+! Define dimensions (add 2 to j_output for poles at -90 and 90)
 !-------------------------------------------------------------------
 
- j_extended = j_target + 2
+ j_extended = j_output + 2
 
  iret = nf90_def_dim(ncid, lat_name, j_extended, lat_dimid)
  if (iret /= nf90_noerr) stop 'ERROR defining lat dimension'
 
- iret = nf90_def_dim(ncid, lon_name, i_target, lon_dimid)
+ iret = nf90_def_dim(ncid, lon_name, i_output, lon_dimid)
  if (iret /= nf90_noerr) stop 'ERROR defining lon dimension'
 
 !-------------------------------------------------------------------
@@ -117,15 +151,15 @@
 ! Write coordinate variables
 !-------------------------------------------------------------------
 
- allocate(out2d(i_target,j_target))
+ allocate(out2d(i_output,j_output))
 
  print*,"WRITE LAT"
- out2d = reshape(rlat_target, (/i_target,j_target/))
+ out2d = reshape(rlat_output, (/i_output,j_output/))
  
 ! Create extended latitude array with -90 at beginning and 90 at end
  allocate(lat_extended(j_extended))
  lat_extended(1) = -90.0
- lat_extended(2:j_target+1) = out2d(1,:)*rad2deg
+ lat_extended(2:j_output+1) = out2d(1,:)*rad2deg
  lat_extended(j_extended) = 90.0
  
  iret = nf90_put_var(ncid, lat_varid, lat_extended)
@@ -134,7 +168,7 @@
  deallocate(lat_extended)
 
  print*,"WRITE LON"
- out2d = reshape(rlon_target, (/i_target,j_target/))
+ out2d = reshape(rlon_output, (/i_output,j_output/))
  iret = nf90_put_var(ncid, lon_varid, out2d(1,:)*rad2deg)
  if (iret /= nf90_noerr) stop 'ERROR writing lon'
 
@@ -144,25 +178,25 @@
 
  print*,"WRITE DTF"
  deallocate(out2d)
- allocate(out2d(i_target,j_extended))
+ allocate(out2d(i_output,j_extended))
  
 ! Fill with dummy value (0.0) at poles
  out2d(:,1) = 0.0
- out2d(:,2:j_target+1) = reshape(dtf, (/i_target,j_target/))
+ out2d(:,2:j_output+1) = reshape(tref_interp, (/i_output,j_output/))
  out2d(:,j_extended) = 0.0
  
- count = (/ i_target, j_extended /)
+ count = (/ i_output, j_extended /)
  start = (/ 1, 1 /)
  
  iret = nf90_put_var(ncid, dtf_varid, out2d, start, count)
  if (iret /= nf90_noerr) stop 'ERROR writing dtf'
 
  print*,"WRITE MSK"
- allocate(msk2d(i_target,j_extended))
+ allocate(msk2d(i_output,j_extended))
  
 ! Fill with dummy value (0) at poles
  msk2d(:,1) = 0
- msk2d(:,2:j_target+1) = reshape(msk_target, (/i_target,j_target/))
+ msk2d(:,2:j_output+1) = reshape(slmsk_lowres, (/i_output,j_output/))
  msk2d(:,j_extended) = 0
  
  iret = nf90_put_var(ncid, msk_varid, msk2d, start, count)
@@ -176,10 +210,12 @@
  if (iret /= nf90_noerr) stop 'ERROR closing file'
 
  deallocate(out2d, msk2d)
- deallocate(dtf)
- deallocate(msk_target)
+ deallocate(tref_interp)
+ deallocate(slmsk_lowres)
 
  print*,"*** SUCCESS writing dtf file ", trim(output_file), "!"
+
+ return
 
  end subroutine write_output_data
 

--- a/src/tref_calc.fd/output_data.f90
+++ b/src/tref_calc.fd/output_data.f90
@@ -1,0 +1,186 @@
+ module output_data
+
+ implicit none
+
+ private
+
+ public                            :: write_output_data
+
+ contains
+
+ subroutine write_output_data
+
+!-------------------------------------------------------------------
+! Write dtf to a netcdf file matching write_tf_inc_nc format.
+!-------------------------------------------------------------------
+
+ use netcdf
+ use input_data
+ use setup
+ use interp
+
+ implicit none
+
+ integer                           :: ncid
+ integer                           :: lat_dimid, lon_dimid
+ integer                           :: lat_varid, lon_varid
+ integer                           :: dtf_varid, msk_varid
+ integer, dimension(2)             :: start, count, dimids
+ real, allocatable                 :: out2d(:,:)
+ integer, allocatable              :: msk2d(:,:)
+ real, allocatable                 :: lat_extended(:)
+ integer                           :: j_extended
+ real, parameter                   :: rad2deg = 57.2957795130823
+ integer                           :: iret
+
+ character (len = *), parameter :: lat_name = "latitude"
+ character (len = *), parameter :: lon_name = "longitude"
+ character (len = *), parameter :: dtf_name = "dtf"
+ character (len = *), parameter :: msk_name = "msk"
+ character (len = *), parameter :: units = "units"
+ character (len = *), parameter :: dtf_units = "kelvin"
+ character (len = *), parameter :: msk_units = "none"
+ character (len = *), parameter :: lat_units = "degrees_north"
+ character (len = *), parameter :: lon_units = "degrees_east"
+
+!-------------------------------------------------------------------
+! Create output file
+!-------------------------------------------------------------------
+
+ print*
+ print*,'CREATE OUTPUT FILE: ',trim(output_file)
+ 
+ iret = nf90_create(trim(output_file), cmode=ior(nf90_clobber,nf90_64bit_offset), ncid=ncid)
+ if (iret /= nf90_noerr) then
+   print*,'ERROR creating file: ',trim(nf90_strerror(iret))
+   stop
+ endif
+
+!-------------------------------------------------------------------
+! Define dimensions (add 2 to j_target for poles at -90 and 90)
+!-------------------------------------------------------------------
+
+ j_extended = j_target + 2
+
+ iret = nf90_def_dim(ncid, lat_name, j_extended, lat_dimid)
+ if (iret /= nf90_noerr) stop 'ERROR defining lat dimension'
+
+ iret = nf90_def_dim(ncid, lon_name, i_target, lon_dimid)
+ if (iret /= nf90_noerr) stop 'ERROR defining lon dimension'
+
+!-------------------------------------------------------------------
+! Define coordinate variables
+!-------------------------------------------------------------------
+
+ iret = nf90_def_var(ncid, lat_name, nf90_real, lat_dimid, lat_varid)
+ if (iret /= nf90_noerr) stop 'ERROR defining lat variable'
+
+ iret = nf90_def_var(ncid, lon_name, nf90_real, lon_dimid, lon_varid)
+ if (iret /= nf90_noerr) stop 'ERROR defining lon variable'
+
+!-------------------------------------------------------------------
+! Assign units to coordinate variables
+!-------------------------------------------------------------------
+
+ iret = nf90_put_att(ncid, lat_varid, units, lat_units)
+ if (iret /= nf90_noerr) stop 'ERROR defining lat units'
+
+ iret = nf90_put_att(ncid, lon_varid, units, lon_units)
+ if (iret /= nf90_noerr) stop 'ERROR defining lon units'
+
+!-------------------------------------------------------------------
+! Define dtf variable
+!-------------------------------------------------------------------
+
+ dimids = (/ lon_dimid, lat_dimid /)
+
+ iret = nf90_def_var(ncid, dtf_name, nf90_double, dimids, dtf_varid)
+ if (iret /= nf90_noerr) stop 'ERROR defining dtf variable'
+
+ iret = nf90_def_var(ncid, msk_name, nf90_byte, dimids, msk_varid)
+ if (iret /= nf90_noerr) stop 'ERROR defining msk variable'
+
+ iret = nf90_put_att(ncid, dtf_varid, units, dtf_units)
+ if (iret /= nf90_noerr) stop 'ERROR defining dtf units'
+
+ iret = nf90_put_att(ncid, msk_varid, units, msk_units)
+ if (iret /= nf90_noerr) stop 'ERROR defining msk units'
+
+!-------------------------------------------------------------------
+! End define mode
+!-------------------------------------------------------------------
+
+ iret = nf90_enddef(ncid)
+ if (iret /= nf90_noerr) stop 'ERROR ending define mode'
+
+!-------------------------------------------------------------------
+! Write coordinate variables
+!-------------------------------------------------------------------
+
+ allocate(out2d(i_target,j_target))
+
+ print*,"WRITE LAT"
+ out2d = reshape(rlat_target, (/i_target,j_target/))
+ 
+! Create extended latitude array with -90 at beginning and 90 at end
+ allocate(lat_extended(j_extended))
+ lat_extended(1) = -90.0
+ lat_extended(2:j_target+1) = out2d(1,:)*rad2deg
+ lat_extended(j_extended) = 90.0
+ 
+ iret = nf90_put_var(ncid, lat_varid, lat_extended)
+ if (iret /= nf90_noerr) stop 'ERROR writing lat'
+ 
+ deallocate(lat_extended)
+
+ print*,"WRITE LON"
+ out2d = reshape(rlon_target, (/i_target,j_target/))
+ iret = nf90_put_var(ncid, lon_varid, out2d(1,:)*rad2deg)
+ if (iret /= nf90_noerr) stop 'ERROR writing lon'
+
+!-------------------------------------------------------------------
+! Write dtf variable (with extended dimension for poles)
+!-------------------------------------------------------------------
+
+ print*,"WRITE DTF"
+ deallocate(out2d)
+ allocate(out2d(i_target,j_extended))
+ 
+! Fill with dummy value (0.0) at poles
+ out2d(:,1) = 0.0
+ out2d(:,2:j_target+1) = reshape(dtf, (/i_target,j_target/))
+ out2d(:,j_extended) = 0.0
+ 
+ count = (/ i_target, j_extended /)
+ start = (/ 1, 1 /)
+ 
+ iret = nf90_put_var(ncid, dtf_varid, out2d, start, count)
+ if (iret /= nf90_noerr) stop 'ERROR writing dtf'
+
+ print*,"WRITE MSK"
+ allocate(msk2d(i_target,j_extended))
+ 
+! Fill with dummy value (0) at poles
+ msk2d(:,1) = 0
+ msk2d(:,2:j_target+1) = reshape(msk_target, (/i_target,j_target/))
+ msk2d(:,j_extended) = 0
+ 
+ iret = nf90_put_var(ncid, msk_varid, msk2d, start, count)
+ if (iret /= nf90_noerr) stop 'ERROR writing msk'
+
+!-------------------------------------------------------------------
+! Close file
+!-------------------------------------------------------------------
+
+ iret = nf90_close(ncid)
+ if (iret /= nf90_noerr) stop 'ERROR closing file'
+
+ deallocate(out2d, msk2d)
+ deallocate(dtf)
+ deallocate(msk_target)
+
+ print*,"*** SUCCESS writing dtf file ", trim(output_file), "!"
+
+ end subroutine write_output_data
+
+ end module output_data

--- a/src/tref_calc.fd/output_data.f90
+++ b/src/tref_calc.fd/output_data.f90
@@ -60,12 +60,11 @@
  integer                           :: lat_varid, lon_varid
  integer                           :: dtf_varid, msk_varid
  integer, dimension(2)             :: start, count, dimids
- real, allocatable                 :: out2d(:,:)
- integer, allocatable              :: msk2d(:,:)
+ real, allocatable                 :: out2d(:,:), out2dflip(:,:)
+ integer, allocatable              :: msk2d(:,:), msk2dflip(:,:)
  real, allocatable                 :: lat_extended(:)
  integer                           :: j_extended
- real, parameter                   :: rad2deg = 57.2957795130823
- integer                           :: iret
+ integer                           :: iflip, iret
 
  character (len = *), parameter :: lat_name = "latitude"
  character (len = *), parameter :: lon_name = "longitude"
@@ -159,7 +158,8 @@
 ! Create extended latitude array with -90 at beginning and 90 at end
  allocate(lat_extended(j_extended))
  lat_extended(1) = -90.0
- lat_extended(2:j_output+1) = out2d(1,:)*rad2deg
+ lat_extended(2:j_output+1) = out2d(1, j_output:1:-1)
+
  lat_extended(j_extended) = 90.0
  
  iret = nf90_put_var(ncid, lat_varid, lat_extended)
@@ -169,7 +169,7 @@
 
  print*,"WRITE LON"
  out2d = reshape(rlon_output, (/i_output,j_output/))
- iret = nf90_put_var(ncid, lon_varid, out2d(1,:)*rad2deg)
+ iret = nf90_put_var(ncid, lon_varid, out2d(1,j_output:1:-1))
  if (iret /= nf90_noerr) stop 'ERROR writing lon'
 
 !-------------------------------------------------------------------
@@ -178,7 +178,7 @@
 
  print*,"WRITE DTF"
  deallocate(out2d)
- allocate(out2d(i_output,j_extended))
+ allocate(out2d(i_output,j_extended), out2dflip(i_output,j_extended))
  
 ! Fill with dummy value (0.0) at poles
  out2d(:,1) = 0.0
@@ -188,18 +188,26 @@
  count = (/ i_output, j_extended /)
  start = (/ 1, 1 /)
  
- iret = nf90_put_var(ncid, dtf_varid, out2d, start, count)
+ do iflip=1,i_output
+   out2dflip(iflip,:) = out2d(iflip, j_extended:1:-1)
+ enddo
+
+ iret = nf90_put_var(ncid, dtf_varid, out2dflip, start, count)
  if (iret /= nf90_noerr) stop 'ERROR writing dtf'
 
  print*,"WRITE MSK"
- allocate(msk2d(i_output,j_extended))
+ allocate(msk2d(i_output,j_extended),msk2dflip(i_output,j_extended))
  
 ! Fill with dummy value (0) at poles
- msk2d(:,1) = 0
+ msk2d(:,1) = 1
  msk2d(:,2:j_output+1) = reshape(slmsk_lowres, (/i_output,j_output/))
- msk2d(:,j_extended) = 0
+ msk2d(:,j_extended) = 1
  
- iret = nf90_put_var(ncid, msk_varid, msk2d, start, count)
+ do iflip=1,i_output
+   msk2dflip(iflip,:) = msk2d(iflip, j_extended:1:-1)
+ enddo
+
+ iret = nf90_put_var(ncid, msk_varid, int(msk2dflip, kind=1), start, count)
  if (iret /= nf90_noerr) stop 'ERROR writing msk'
 
 !-------------------------------------------------------------------

--- a/src/tref_calc.fd/setup.f90
+++ b/src/tref_calc.fd/setup.f90
@@ -1,0 +1,52 @@
+ module setup
+
+ implicit none
+
+ private
+
+ character(len=300), public       :: sfcanl_file
+ character(len=300), public       :: sfcf006_file
+ character(len=300), public       :: output_file
+
+ integer, public  :: i_target
+ integer, public  :: j_target
+ integer, public  :: ij_target
+
+ integer, public  :: i_source
+ integer, public  :: j_source
+ integer, public  :: ij_source
+
+ public                           :: program_setup
+
+ contains
+
+ subroutine program_setup
+
+ implicit none
+
+ integer                           :: istat
+ character(len=500)                :: filenamelist
+
+ namelist /tref_calc_setup/ sfcanl_file, sfcf006_file, output_file
+
+ print*
+ call getarg(1,filenamelist)
+ print*,"OPEN SETUP NAMELIST ",trim(filenamelist)
+ open(43, file=filenamelist, iostat=istat)
+ if (istat /= 0) then
+   print*,"FATAL ERROR OPENING NAMELIST FILE. ISTAT IS: ",istat
+   stop 
+ endif
+
+ print*,"READ SETUP NAMELIST."
+ read(43, nml=tref_calc_setup, iostat=istat)
+ if (istat /= 0) then
+   print*,"FATAL ERROR READING NAMELIST FILE. ISTAT IS: ",istat
+   stop
+ endif
+
+ close(43)
+
+ end subroutine program_setup
+
+ end module setup

--- a/src/tref_calc.fd/setup.f90
+++ b/src/tref_calc.fd/setup.f90
@@ -8,13 +8,10 @@
  character(len=300), public       :: sfcf006_file
  character(len=300), public       :: output_file
 
- integer, public  :: i_target
- integer, public  :: j_target
- integer, public  :: ij_target
-
- integer, public  :: i_source
- integer, public  :: j_source
- integer, public  :: ij_source
+ integer, public  :: i_output
+ integer, public  :: j_output
+ integer                , public  :: ij_output
+ logical, public :: cld_amt
 
  public                           :: program_setup
 
@@ -27,7 +24,7 @@
  integer                           :: istat
  character(len=500)                :: filenamelist
 
- namelist /tref_calc_setup/ sfcanl_file, sfcf006_file, output_file
+ namelist /tref_calc_setup/ i_output, j_output, sfcanl_file, sfcf006_file, output_file
 
  print*
  call getarg(1,filenamelist)
@@ -44,6 +41,8 @@
    print*,"FATAL ERROR READING NAMELIST FILE. ISTAT IS: ",istat
    stop
  endif
+
+ ij_output = i_output * j_output
 
  close(43)
 

--- a/src/tref_calc.fd/setup.f90
+++ b/src/tref_calc.fd/setup.f90
@@ -11,7 +11,6 @@
  integer, public  :: i_output
  integer, public  :: j_output
  integer                , public  :: ij_output
- logical, public :: cld_amt
 
  public                           :: program_setup
 

--- a/src/tref_calc.fd/utils.f90
+++ b/src/tref_calc.fd/utils.f90
@@ -1,0 +1,736 @@
+ module utils
+
+ private
+
+ public :: calc_kgds
+ public :: newps
+ public :: newpr1
+ public :: vintg
+ public :: compute_delz
+
+ contains
+
+ subroutine compute_delz(ijm, levp, ak_in, bk_in, ps, zs, t, sphum, delz)
+
+ implicit none
+ integer, intent(in):: levp, ijm
+ real,    intent(in), dimension(levp+1):: ak_in, bk_in
+ real,    intent(in), dimension(ijm):: ps, zs
+ real,    intent(in), dimension(ijm,levp):: t
+ real,    intent(in), dimension(ijm,levp):: sphum
+ real,    intent(out), dimension(ijm,levp):: delz
+! Local:
+ real, dimension(ijm,levp+1):: zh
+ real, dimension(ijm,levp+1):: pe0, pn0
+ real, dimension(levp+1) :: ak, bk
+ integer i,k
+ real, parameter :: GRAV   = 9.80665
+ real, parameter :: RDGAS  = 287.05
+ real, parameter :: RVGAS = 461.50
+ real  :: zvir
+ real:: grd
+
+ print*,"COMPUTE LAYER THICKNESS."
+
+ grd = grav/rdgas
+ zvir = rvgas/rdgas - 1.
+ ak = ak_in
+ bk = bk_in
+ ak(levp+1) = max(1.e-9, ak(levp+1))
+
+ do i=1, ijm
+   pe0(i,levp+1) = ak(levp+1)
+   pn0(i,levp+1) = log(pe0(i,levp+1))
+ enddo
+
+ do k=levp,1, -1
+   do i=1,ijm
+     pe0(i,k) = ak(k) + bk(k)*ps(i)
+     pn0(i,k) = log(pe0(i,k))
+   enddo
+ enddo
+
+ do i = 1, ijm
+   zh(i,1) = zs(i)
+ enddo
+
+ do k = 2, levp+1
+   do i = 1, ijm
+     zh(i,k) = zh(i,k-1)+t(i,k-1)*(1.+zvir*sphum(i,k-1))*     &
+            (pn0(i,k-1)-pn0(i,k))/grd
+   enddo
+ enddo
+
+ do k = 1, levp
+   do i = 1, ijm
+     delz(i,k) = zh(i,k) - zh(i,k+1)
+   enddo
+ enddo
+
+ end subroutine compute_delz
+
+ subroutine calc_kgds(idim, jdim, kgds)
+
+ implicit none
+
+ integer, intent(in)  :: idim, jdim
+
+ integer, intent(out)                 :: kgds(200)
+
+ kgds     = 0
+ kgds(1)  = 4                       ! OCT 6 - TYPE OF GRID (GAUSSIAN)
+ kgds(2)  = idim                    ! OCT 7-8 - # PTS ON LATITUDE CIRCLE
+ kgds(3)  = jdim                    ! OCT 9-10 - # PTS ON LONGITUDE CIRCLE
+ kgds(4)  = 90000                   ! OCT 11-13 - LAT OF ORIGIN
+ kgds(5)  = 0                       ! OCT 14-16 - LON OF ORIGIN
+ kgds(6)  = 128                     ! OCT 17 - RESOLUTION FLAG
+ kgds(7)  = -90000                  ! OCT 18-20 - LAT OF EXTREME POINT
+ kgds(8)  = nint(-360000./idim)     ! OCT 21-23 - LON OF EXTREME POINT
+ kgds(9)  = nint((360.0 / float(idim))*1000.0)
+                                          ! OCT 24-25 - LONGITUDE DIRECTION INCR.
+ kgds(10) = jdim/2                  ! OCT 26-27 - NUMBER OF CIRCLES POLE TO EQUATOR
+ kgds(12) = 255                     ! OCT 29 - RESERVED
+ kgds(20) = 255                     ! OCT 5  - NOT USED, SET TO 255
+
+ end subroutine calc_kgds
+
+ SUBROUTINE NEWPS(ZS,PS,IM,KM,P,T,Q,ZSNEW,PSNEW)
+!$$$  SUBPROGRAM DOCUMENTATION BLOCK
+!
+! SUBPROGRAM:    NEWPS       COMPUTE NEW SURFACE PRESSURE
+!   PRGMMR: IREDELL          ORG: W/NMC23     DATE: 92-10-31
+!
+! ABSTRACT: COMPUTES A NEW SURFACE PRESSURE GIVEN A NEW OROGRAPHY.
+!   THE NEW PRESSURE IS COMPUTED ASSUMING A HYDROSTATIC BALANCE
+!   AND A CONSTANT TEMPERATURE LAPSE RATE.  BELOW GROUND, THE
+!   LAPSE RATE IS ASSUMED TO BE -6.5 K/KM.
+!
+! PROGRAM HISTORY LOG:
+!   91-10-31  MARK IREDELL
+!
+! USAGE:    CALL NEWPS(ZS,PS,IM,KM,P,T,Q,ZSNEW,PSNEW)
+!   INPUT ARGUMENT LIST:
+!     IM           INTEGER NUMBER OF POINTS TO COMPUTE
+!     ZS           REAL (IM) OLD OROGRAPHY (M)
+!     PS           REAL (IM) OLD SURFACE PRESSURE (PA)
+!     KM           INTEGER NUMBER OF LEVELS
+!     P            REAL (IM,KM) PRESSURES (PA)
+!     T            REAL (IM,KM) TEMPERATURES (K)
+!     Q            REAL (IM,KM) SPECIFIC HUMIDITIES (KG/KG)
+!     ZSNEW        REAL (IM) NEW OROGRAPHY (M)
+!   OUTPUT ARGUMENT LIST:
+!     PSNEW        REAL (IM) NEW SURFACE PRESSURE (PA)
+!
+! ATTRIBUTES:
+!   LANGUAGE: FORTRAN
+!
+!C$$$
+      REAL ZS(IM),PS(IM),P(IM,KM),T(IM,KM),Q(IM,KM)
+      REAL ZSNEW(IM),PSNEW(IM)
+      PARAMETER(BETA=-6.5E-3,EPSILON=1.E-9)
+      PARAMETER(G=9.80665,RD=287.05,RV=461.50)
+      PARAMETER(GOR=G/RD,FV=RV/RD-1.)
+      REAL ZU(IM)
+      FTV(AT,AQ)=AT*(1+FV*AQ)
+      FGAM(APU,ATVU,APD,ATVD)=-GOR*LOG(ATVD/ATVU)/LOG(APD/APU)
+      FZ0(AP,ATV,AZD,APD)=AZD+ATV/GOR*LOG(APD/AP)
+      FZ1(AP,ATV,AZD,APD,AGAM)=AZD-ATV/AGAM*((APD/AP)**(-AGAM/GOR)-1)
+      FP0(AZ,AZU,APU,ATVU)=APU*EXP(-GOR/ATVU*(AZ-AZU))
+      FP1(AZ,AZU,APU,ATVU,AGAM)=APU*(1+AGAM/ATVU*(AZ-AZU))**(-GOR/AGAM)
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  COMPUTE SURFACE PRESSURE BELOW THE ORIGINAL GROUND
+      LS=0
+      K=1
+      GAMMA=BETA
+      DO I=1,IM
+          PU=P(I,K)
+          TVU=FTV(T(I,K),Q(I,K))
+          ZU(I)=FZ1(PU,TVU,ZS(I),PS(I),GAMMA)
+          IF(ZSNEW(I).LE.ZU(I)) THEN
+            PU=P(I,K)
+            TVU=FTV(T(I,K),Q(I,K))
+            IF(ABS(GAMMA).GT.EPSILON) THEN
+              PSNEW(I)=FP1(ZSNEW(I),ZU(I),PU,TVU,GAMMA)
+            ELSE
+              PSNEW(I)=FP0(ZSNEW(I),ZU(I),PU,TVU)
+            ENDIF
+          ELSE
+            PSNEW(I)=0
+            LS=LS+1
+          ENDIF
+!       endif
+      ENDDO
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  COMPUTE SURFACE PRESSURE ABOVE THE ORIGINAL GROUND
+      DO K=2,KM
+        IF(LS.GT.0) THEN
+          DO I=1,IM
+            IF(PSNEW(I).EQ.0) THEN
+              PU=P(I,K)
+              TVU=FTV(T(I,K),Q(I,K))
+              PD=P(I,K-1)
+              TVD=FTV(T(I,K-1),Q(I,K-1))
+              GAMMA=FGAM(PU,TVU,PD,TVD)
+              IF(ABS(GAMMA).GT.EPSILON) THEN
+                ZU(I)=FZ1(PU,TVU,ZU(I),PD,GAMMA)
+              ELSE
+                ZU(I)=FZ0(PU,TVU,ZU(I),PD)
+              ENDIF
+              IF(ZSNEW(I).LE.ZU(I)) THEN
+                IF(ABS(GAMMA).GT.EPSILON) THEN
+                  PSNEW(I)=FP1(ZSNEW(I),ZU(I),PU,TVU,GAMMA)
+                ELSE
+                  PSNEW(I)=FP0(ZSNEW(I),ZU(I),PU,TVU)
+                ENDIF
+                LS=LS-1
+              ENDIF
+            ENDIF
+          ENDDO
+        ENDIF
+      ENDDO
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  COMPUTE SURFACE PRESSURE OVER THE TOP
+      IF(LS.GT.0) THEN
+        K=KM
+        GAMMA=0
+        DO I=1,IM
+          IF(PSNEW(I).EQ.0) THEN
+            PU=P(I,K)
+            TVU=FTV(T(I,K),Q(I,K))
+            PSNEW(I)=FP0(ZSNEW(I),ZU(I),PU,TVU)
+          ENDIF
+        ENDDO
+      ENDIF
+ END SUBROUTINE NEWPS
+
+ SUBROUTINE NEWPR1(IM,KM,IDVC,IDSL,NVCOORD,VCOORD,     &
+                   PS,PM,DP)
+!$$$  SUBPROGRAM DOCUMENTATION BLOCK
+!
+! SUBPROGRAM:    NEWPR1      COMPUTE MODEL PRESSURES
+!   PRGMMR: JUANG          ORG: W/NMC23     DATE: 2005-04-11
+!   PRGMMR: Fanglin Yang   ORG: W/NMC23     DATE: 2006-11-28
+!   PRGMMR: S. Moorthi     ORG: NCEP/EMC    DATE: 2006-12-12
+!   PRGMMR: S. Moorthi     ORG: NCEP/EMC    DATE: 2007-01-02
+!
+! ABSTRACT: COMPUTE MODEL PRESSURES.
+!
+! PROGRAM HISTORY LOG:
+! 2005-04-11  HANN_MING HENRY JUANG    hybrid sigma, sigma-p, and sigma-
+!
+! USAGE:    CALL NEWPR1(IM,IX,KM,KMP,IDVC,IDSL,NVCOORD,VCOORD,PP,TP,QP,P
+!   INPUT ARGUMENT LIST:
+!     IM           INTEGER NUMBER OF POINTS TO COMPUTE
+!     KM           INTEGER NUMBER OF LEVELS
+!     IDVC         INTEGER VERTICAL COORDINATE ID
+!                  (1 FOR SIGMA AND 2 FOR HYBRID)
+!     IDSL         INTEGER TYPE OF SIGMA STRUCTURE
+!                  (1 FOR PHILLIPS OR 2 FOR MEAN)
+!     NVCOORD      INTEGER NUMBER OF VERTICAL COORDINATES
+!     VCOORD       REAL (KM+1,NVCOORD) VERTICAL COORDINATE VALUES
+!                  FOR IDVC=1, NVCOORD=1: SIGMA INTERFACE
+!                  FOR IDVC=2, NVCOORD=2: HYBRID INTERFACE A AND B
+!                  FOR IDVC=3, NVCOORD=3: JUANG GENERAL HYBRID INTERFACE
+!                     AK  REAL (KM+1) HYBRID INTERFACE A
+!                     BK  REAL (KM+1) HYBRID INTERFACE B
+!     PS           REAL (IX) SURFACE PRESSURE (PA)
+!   OUTPUT ARGUMENT LIST:
+!     PM           REAL (IX,KM) MID-LAYER PRESSURE (PA)
+!     DP           REAL (IX,KM) LAYER DELTA PRESSURE (PA)
+!
+! ATTRIBUTES:
+!   LANGUAGE: FORTRAN
+!
+!C$$$
+ IMPLICIT NONE
+
+ INTEGER, INTENT(IN)     :: IM, KM, NVCOORD, IDVC, IDSL
+
+ REAL, INTENT(IN)        :: VCOORD(KM+1,NVCOORD)
+ REAL, INTENT(IN)        :: PS(IM)
+
+ REAL, INTENT(OUT)       :: PM(IM,KM)
+ REAL, OPTIONAL, INTENT(OUT) :: DP(IM,KM)
+
+ REAL, PARAMETER :: RD=287.05,  RV=461.50,    CP=1004.6,           &
+                    ROCP=RD/CP, ROCP1=ROCP+1, ROCPR=1/ROCP,        &
+                   FV=RV/RD-1.
+
+ INTEGER                 :: I, K
+
+ REAL                    :: AK(KM+1), BK(KM+1), PI(IM,KM+1)
+
+ IF(IDVC.EQ.2) THEN
+   DO K=1,KM+1
+     AK(K)      = VCOORD(K,1)
+     BK(K)      = VCOORD(K,2)
+     PI(:,K) = AK(K) + BK(K)*PS(:)
+   ENDDO
+ ELSE
+   print*,'routine only works for idvc 2'
+   stop
+ ENDIF
+
+ IF(IDSL.EQ.2) THEN
+   DO K=1,KM
+     PM(1:IM,K) = (PI(1:IM,K)+PI(1:IM,K+1))/2
+   ENDDO
+ ELSE
+   DO K=1,KM
+     PM(1:IM,K) = ((PI(1:IM,K)**ROCP1-PI(1:IM,K+1)**ROCP1)/        &
+                   (ROCP1*(PI(1:IM,K)-PI(1:IM,K+1))))**ROCPR
+   ENDDO
+ ENDIF
+
+ IF(PRESENT(DP))THEN
+   DO K=1,KM
+     DO I=1,IM
+       DP(I,K) = PI(I,K) - PI(I,K+1)
+     ENDDO
+   ENDDO
+ ENDIF
+
+ END SUBROUTINE NEWPR1
+
+ SUBROUTINE RSEARCH(KM1,Z1,KM2,Z2,L2)
+!$$$  SUBPROGRAM DOCUMENTATION BLOCK
+!
+! SUBPROGRAM:    RSEARCH     SEARCH FOR A SURROUNDING REAL INTERVAL
+!   PRGMMR: IREDELL          ORG: W/NMC23     DATE: 98-05-01
+!
+! ABSTRACT: THIS SUBPROGRAM SEARCHES MONOTONIC SEQUENCES OF REAL NUMBERS
+!   FOR INTERVALS THAT SURROUND A GIVEN SEARCH SET OF REAL NUMBERS.
+!   THE SEQUENCES MAY BE MONOTONIC IN EITHER DIRECTION; THE REAL NUMBERS
+!   MAY BE SINGLE OR DOUBLE PRECISION; THE INPUT SEQUENCES AND SETS
+!   AND THE OUTPUT LOCATIONS MAY BE ARBITRARILY DIMENSIONED.
+!
+! PROGRAM HISTORY LOG:
+! 1999-01-05  MARK IREDELL
+! 2022-06-16  CONVERT TO SINGLE COLUMN PROCESSING. GDIT
+!
+! USAGE:    CALL RSEARCH(KM1,Z1,KM2,Z2,L2)
+!
+!   INPUT ARGUMENT LIST:
+!     KM1          INTEGER NUMBER OF POINTS IN THE SEQUENCE.
+!     Z1           REAL SEQUENCE VALUES TO SEARCH.
+!                  (Z1 MUST BE MONOTONIC IN EITHER DIRECTION)
+!     KM2          INTEGER NUMBER OF POINTS TO SEARCH FOR
+!                  IN THE SEQUENCE
+!     Z2           REAL SET OF VALUES TO SEARCH FOR.
+!                  (Z2 NEED NOT BE MONOTONIC)
+!
+!   OUTPUT ARGUMENT LIST:
+!     L2           INTEGER INTERVAL LOCATIONS HAVING VALUES FROM
+!                  0 TO KM1. (Z2 WILL BE BETWEEN Z1(L2) AND Z1(L2+1))
+!
+! REMARKS:
+!
+!   RETURNED VALUES OF 0 OR KM1 INDICATE THAT THE GIVEN SEARCH VALUE
+!   IS OUTSIDE THE RANGE OF THE SEQUENCE.
+!
+!   IF A SEARCH VALUE IS IDENTICAL TO ONE OF THE SEQUENCE VALUES
+!   THEN THE LOCATION RETURNED POINTS TO THE IDENTICAL VALUE.
+!   IF THE SEQUENCE IS NOT STRICTLY MONOTONIC AND A SEARCH VALUE IS
+!   IDENTICAL TO MORE THAN ONE OF THE SEQUENCE VALUES, THEN THE
+!   LOCATION RETURNED MAY POINT TO ANY OF THE IDENTICAL VALUES.
+!
+!   TO BE EXACT, FOR K FROM 1 TO KM2, Z=Z2(K) IS THE SEARCH VALUE
+!   AND L=L2(K) IS THE LOCATION RETURNED.
+!
+!   IF L=0, THEN Z IS LESS THAN THE START POINT Z1(1)
+!   FOR ASCENDING SEQUENCES (OR GREATER THAN FOR DESCENDING SEQUENCES).
+!   IF L=KM1, THEN Z IS GREATER THAN OR EQUAL TO THE END POINT
+!   Z1(KM1) FOR ASCENDING SEQUENCES (OR LESS THAN OR EQUAL 
+!   TO FOR DESCENDING SEQUENCES). OTHERWISE Z IS BETWEEN
+!   THE VALUES Z1(L) AND Z1(1+L) AND MAY EQUAL THE FORMER.
+!
+! ATTRIBUTES:
+!   LANGUAGE: FORTRAN
+!
+!C$$$
+      IMPLICIT NONE
+      INTEGER,INTENT(IN):: KM1,KM2
+      REAL,INTENT(IN):: Z1(KM1)
+      REAL,INTENT(IN):: Z2(KM2)
+      INTEGER,INTENT(OUT):: L2(KM2)
+      INTEGER K2,L
+      REAL Z
+!C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!C  FIND THE SURROUNDING INPUT INTERVAL FOR EACH OUTPUT POINT.
+
+        IF(Z1(1).LE.Z1(km1)) THEN
+!C  INPUT COORDINATE IS MONOTONICALLY ASCENDING.
+          DO K2=1,KM2
+            Z=Z2(K2)
+            L=0
+            DO
+              IF(Z.LT.Z1(L+1)) EXIT
+              L=L+1
+              IF(L.EQ.KM1) EXIT
+            ENDDO
+            L2(K2)=L
+          ENDDO
+        ELSE
+!C  INPUT COORDINATE IS MONOTONICALLY DESCENDING.
+          DO K2=1,KM2
+            Z=Z2(K2)
+            L=0
+            DO
+              IF(Z.GT.Z1(L+1)) EXIT
+              L=L+1
+              IF(L.EQ.KM1) EXIT
+            ENDDO
+            L2(K2)=L
+          ENDDO
+        ENDIF
+
+ END SUBROUTINE RSEARCH
+
+ SUBROUTINE VINTG(IM,KM1,KM2,NT,P1,U1,V1,T1,Q1,W1,P2, &
+                  U2,V2,T2,Q2,W2)
+!$$$  SUBPROGRAM DOCUMENTATION BLOCK
+!
+! SUBPROGRAM:    VINTG       VERTICALLY INTERPOLATE UPPER-AIR FIELDS
+!   PRGMMR: IREDELL          ORG: W/NMC23     DATE: 92-10-31
+!
+! ABSTRACT: VERTICALLY INTERPOLATE UPPER-AIR FIELDS.
+!   WIND, TEMPERATURE, HUMIDITY AND OTHER TRACERS ARE INTERPOLATED.
+!   THE INTERPOLATION IS CUBIC LAGRANGIAN IN LOG PRESSURE
+!   WITH A MONOTONIC CONSTRAINT IN THE CENTER OF THE DOMAIN.
+!   IN THE OUTER INTERVALS IT IS LINEAR IN LOG PRESSURE.
+!   OUTSIDE THE DOMAIN, FIELDS ARE GENERALLY HELD CONSTANT,
+!   EXCEPT FOR TEMPERATURE AND HUMIDITY BELOW THE INPUT DOMAIN,
+!   WHERE THE TEMPERATURE LAPSE RATE IS HELD FIXED AT -6.5 K/KM AND
+!   THE RELATIVE HUMIDITY IS HELD CONSTANT.
+!
+! PROGRAM HISTORY LOG:
+!   91-10-31  MARK IREDELL
+!
+! USAGE:    CALL VINTG(IM,KM1,KM2,NT,P1,U1,V1,T1,Q1,P2,
+!    &                 U2,V2,T2,Q2)
+!   INPUT ARGUMENT LIST:
+!     IM           INTEGER NUMBER OF POINTS TO COMPUTE
+!     KM1          INTEGER NUMBER OF INPUT LEVELS
+!     KM2          INTEGER NUMBER OF OUTPUT LEVELS
+!     NT           INTEGER NUMBER OF TRACERS
+!     P1           REAL (IM,KM1) INPUT PRESSURES
+!                  ORDERED FROM BOTTOM TO TOP OF ATMOSPHERE
+!     U1           REAL (IM,KM1) INPUT ZONAL WIND
+!     V1           REAL (IM,KM1) INPUT MERIDIONAL WIND
+!     T1           REAL (IM,KM1) INPUT TEMPERATURE (K)
+!     Q1           REAL (IM,KM1,NT) INPUT TRACERS (HUMIDITY FIRST)
+!     P2           REAL (IM,KM2) OUTPUT PRESSURES
+!   OUTPUT ARGUMENT LIST:
+!     U2           REAL (IM,KM2) OUTPUT ZONAL WIND
+!     V2           REAL (IM,KM2) OUTPUT MERIDIONAL WIND
+!     T2           REAL (IM,KM2) OUTPUT TEMPERATURE (K)
+!     Q2           REAL (IM,KM2,NT) OUTPUT TRACERS (HUMIDITY FIRST)
+!
+! SUBPROGRAMS CALLED:
+!   TERP3        CUBICALLY INTERPOLATE IN ONE DIMENSION
+!
+! ATTRIBUTES:
+!   LANGUAGE: FORTRAN
+!
+!C$$$
+      IMPLICIT NONE
+
+
+      INTEGER, INTENT(IN)      :: IM, KM1, KM2, NT
+
+      REAL,    INTENT(IN)      :: P1(IM,KM1),U1(IM,KM1),V1(IM,KM1)
+      REAL,    INTENT(IN)      :: T1(IM,KM1),Q1(IM,KM1,NT)
+      REAL,    INTENT(IN)      :: W1(IM,KM1),P2(IM,KM2)
+      REAL,    INTENT(OUT)     :: U2(IM,KM2),V2(IM,KM2)
+      REAL,    INTENT(OUT)     :: T2(IM,KM2),Q2(IM,KM2,NT)
+      REAL,    INTENT(OUT)     :: W2(IM,KM2)
+
+      REAL, PARAMETER          :: DLTDZ=-6.5E-3*287.05/9.80665
+      REAL, PARAMETER          :: DLPVDRT=-2.5E6/461.50
+
+      INTEGER                  :: I, K, N
+
+      REAL                     :: DZ
+      REAL,ALLOCATABLE         :: Z1(:,:),Z2(:,:)
+      REAL,ALLOCATABLE         :: C1(:,:,:),C2(:,:,:),J2(:,:,:)
+
+      ALLOCATE (Z1(IM+1,KM1),Z2(IM+1,KM2))
+      ALLOCATE (C1(IM+1,KM1,4+NT),C2(IM+1,KM2,4+NT),J2(IM+1,KM2,4+NT))
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  COMPUTE LOG PRESSURE INTERPOLATING COORDINATE
+!  AND COPY INPUT WIND, TEMPERATURE, HUMIDITY AND OTHER TRACERS
+!$OMP PARALLEL DO PRIVATE(K,I)
+      DO K=1,KM1
+        DO I=1,IM
+          Z1(I,K)   = -LOG(P1(I,K))
+          C1(I,K,1) =  U1(I,K)
+          C1(I,K,2) =  V1(I,K)
+          C1(I,K,3) =  W1(I,K)
+          C1(I,K,4) =  T1(I,K)
+          C1(I,K,5) =  Q1(I,K,1)
+        ENDDO
+      ENDDO
+!$OMP END PARALLEL DO
+      DO N=2,NT
+        DO K=1,KM1
+          DO I=1,IM
+            C1(I,K,4+N) = Q1(I,K,N)
+          ENDDO
+        ENDDO
+      ENDDO
+!$OMP PARALLEL DO PRIVATE(K,I)
+      DO K=1,KM2
+        DO I=1,IM
+          Z2(I,K) = -LOG(P2(I,K))
+        ENDDO
+      ENDDO
+!$OMP END PARALLEL DO
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  PERFORM LAGRANGIAN ONE-DIMENSIONAL INTERPOLATION
+!  THAT IS 4TH-ORDER IN INTERIOR, 2ND-ORDER IN OUTSIDE INTERVALS
+!  AND 1ST-ORDER FOR EXTRAPOLATION.
+      CALL TERP3(IM,1,1,1,1,4+NT,(IM+1)*KM1,(IM+1)*KM2, &
+                 KM1,IM+1,IM+1,Z1,C1,KM2,IM+1,IM+1,Z2,C2,J2)
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  COPY OUTPUT WIND, TEMPERATURE, HUMIDITY AND OTHER TRACERS
+!  EXCEPT BELOW THE INPUT DOMAIN, LET TEMPERATURE INCREASE WITH A FIXED
+!  LAPSE RATE AND LET THE RELATIVE HUMIDITY REMAIN CONSTANT.
+      DO K=1,KM2
+        DO I=1,IM
+          U2(I,K)=C2(I,K,1)
+          V2(I,K)=C2(I,K,2)
+          W2(I,K)=C2(I,K,3)
+          DZ=Z2(I,K)-Z1(I,1)
+          IF(DZ.GE.0) THEN
+            T2(I,K)=C2(I,K,4)
+            Q2(I,K,1)=C2(I,K,5)
+          ELSE
+            T2(I,K)=T1(I,1)*EXP(DLTDZ*DZ)
+            Q2(I,K,1)=Q1(I,1,1)*EXP(DLPVDRT*(1/T2(I,K)-1/T1(I,1))-DZ)
+          ENDIF
+        ENDDO
+      ENDDO
+      DO N=2,NT
+        DO K=1,KM2
+          DO I=1,IM
+            Q2(I,K,N)=C2(I,K,4+N)
+          ENDDO
+        ENDDO
+      ENDDO
+      DEALLOCATE (Z1,Z2,C1,C2,J2)
+ END SUBROUTINE VINTG
+
+
+ SUBROUTINE TERP3(IM,IXZ1,IXQ1,IXZ2,IXQ2,NM,NXQ1,NXQ2,             &
+                  KM1,KXZ1,KXQ1,Z1,Q1,KM2,KXZ2,KXQ2,Z2,Q2,J2)
+!$$$  SUBPROGRAM DOCUMENTATION BLOCK
+!
+! SUBPROGRAM:    TERP3       CUBICALLY INTERPOLATE IN ONE DIMENSION
+!   PRGMMR: IREDELL          ORG: W/NMC23     DATE: 98-05-01
+!
+! ABSTRACT: INTERPOLATE FIELD(S) IN ONE DIMENSION ALONG THE COLUMN(S).
+!   THE INTERPOLATION IS CUBIC LAGRANGIAN WITH A MONOTONIC CONSTRAINT
+!   IN THE CENTER OF THE DOMAIN.  IN THE OUTER INTERVALS IT IS LINEAR.
+!   OUTSIDE THE DOMAIN, FIELDS ARE HELD CONSTANT.
+!
+! PROGRAM HISTORY LOG:
+!   98-05-01  MARK IREDELL
+! 1999-01-04  IREDELL  USE ESSL SEARCH
+!
+! USAGE:    CALL TERP3(IM,IXZ1,IXQ1,IXZ2,IXQ2,NM,NXQ1,NXQ2,
+!    &                 KM1,KXZ1,KXQ1,Z1,Q1,KM2,KXZ2,KXQ2,Z2,Q2,J2)
+!   INPUT ARGUMENT LIST:
+!     IM           INTEGER NUMBER OF COLUMNS
+!     IXZ1         INTEGER COLUMN SKIP NUMBER FOR Z1
+!     IXQ1         INTEGER COLUMN SKIP NUMBER FOR Q1
+!     IXZ2         INTEGER COLUMN SKIP NUMBER FOR Z2
+!     IXQ2         INTEGER COLUMN SKIP NUMBER FOR Q2
+!     NM           INTEGER NUMBER OF FIELDS PER COLUMN
+!     NXQ1         INTEGER FIELD SKIP NUMBER FOR Q1
+!     NXQ2         INTEGER FIELD SKIP NUMBER FOR Q2
+!     KM1          INTEGER NUMBER OF INPUT POINTS
+!     KXZ1         INTEGER POINT SKIP NUMBER FOR Z1
+!     KXQ1         INTEGER POINT SKIP NUMBER FOR Q1
+!     Z1           REAL (1+(IM-1)*IXZ1+(KM1-1)*KXZ1)
+!                  INPUT COORDINATE VALUES IN WHICH TO INTERPOLATE
+!                  (Z1 MUST BE STRICTLY MONOTONIC IN EITHER DIRECTION)
+!     Q1           REAL (1+(IM-1)*IXQ1+(KM1-1)*KXQ1+(NM-1)*NXQ1)
+!                  INPUT FIELDS TO INTERPOLATE
+!     KM2          INTEGER NUMBER OF OUTPUT POINTS
+!     KXZ2         INTEGER POINT SKIP NUMBER FOR Z2
+!     KXQ2         INTEGER POINT SKIP NUMBER FOR Q2
+!     Z2           REAL (1+(IM-1)*IXZ2+(KM2-1)*KXZ2)
+!                  OUTPUT COORDINATE VALUES TO WHICH TO INTERPOLATE
+!                  (Z2 NEED NOT BE MONOTONIC)
+!
+!   OUTPUT ARGUMENT LIST:
+!     Q2           REAL (1+(IM-1)*IXQ2+(KM2-1)*KXQ2+(NM-1)*NXQ2)
+!                  OUTPUT INTERPOLATED FIELDS
+!     J2           REAL (1+(IM-1)*IXQ2+(KM2-1)*KXQ2+(NM-1)*NXQ2)
+!                  OUTPUT INTERPOLATED FIELDS CHANGE WRT Z2
+!
+! SUBPROGRAMS CALLED:
+!   RSEARCH      SEARCH FOR A SURROUNDING REAL INTERVAL
+!
+! ATTRIBUTES:
+!   LANGUAGE: FORTRAN
+!
+!C$$$
+
+      IMPLICIT NONE
+      INTEGER, intent(in) :: IM,IXZ1,IXQ1,IXZ2,IXQ2,NM,NXQ1,NXQ2
+      INTEGER, intent(in) :: KM1,KXZ1,KXQ1,KM2,KXZ2,KXQ2
+
+      REAL, intent(in) :: Z1(1+(IM-1)*IXZ1+(KM1-1)*KXZ1)
+      REAL, intent(in) :: Q1(1+(IM-1)*IXQ1+(KM1-1)*KXQ1+(NM-1)*NXQ1)
+      REAL, intent(in) :: Z2(1+(IM-1)*IXZ2+(KM2-1)*KXZ2)
+      REAL, intent(inout) :: Q2(1+(IM-1)*IXQ2+(KM2-1)*KXQ2+(NM-1)*NXQ2)
+      REAL, intent(inout) :: J2(1+(IM-1)*IXQ2+(KM2-1)*KXQ2+(NM-1)*NXQ2)
+      INTEGER I,K1,K2,N
+      REAL FFA(IM),FFB(IM),FFC(IM),FFD(IM)
+      REAL GGA(IM),GGB(IM),GGC(IM),GGD(IM)
+      INTEGER K1S(IM,KM2)
+      INTEGER,allocatable :: kpz(:)
+      REAL, allocatable :: zpz1(:), zpz2(:)
+      REAL Z1A,Z1B,Z1C,Z1D,Q1A,Q1B,Q1C,Q1D,Z2S,Q2S,J2S
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      allocate(kpz(km2))
+      allocate(zpz1(km1), zpz2(km2))
+
+!  FIND THE SURROUNDING INPUT INTERVAL FOR EACH OUTPUT POINT.
+! PJJ/GDIT - RSEARCH modified to search single vertical column
+!            copy column to temp arrays before call to RSEARCH
+      do i=1,im
+        do k2=1,km1
+          zpz1(k2)=z1(1+(I-1)*IXZ1+(k2-1)*KXZ1)
+        enddo
+        do k2=1,km2
+          zpz2(k2)=z2(1+(I-1)*IXZ2+(k2-1)*KXZ2)
+        enddo
+
+        CALL RSEARCH(KM1,zpz1,KM2,zpz2,kpz)
+
+        do k2=1,km2
+          k1s(i,k2)=kpz(k2)
+        enddo
+      enddo
+
+      deallocate(kpz)
+      deallocate(zpz1,zpz2)
+
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  GENERALLY INTERPOLATE CUBICALLY WITH MONOTONIC CONSTRAINT
+!  FROM TWO NEAREST INPUT POINTS ON EITHER SIDE OF THE OUTPUT POINT,
+!  BUT WITHIN THE TWO EDGE INTERVALS INTERPOLATE LINEARLY.
+!  KEEP THE OUTPUT FIELDS CONSTANT OUTSIDE THE INPUT DOMAIN.
+
+!!$OMP PARALLEL DO DEFAULT(PRIVATE) SHARED(IM,IXZ1,IXQ1,IXZ2), &
+!!$OMP& SHARED(IXQ2,NM,NXQ1,NXQ2,KM1,KXZ1,KXQ1,Z1,Q1,KM2,KXZ2), &
+!!$OMP& SHARED(KXQ2,Z2,Q2,J2,K1S)
+
+      DO K2=1,KM2
+        DO I=1,IM
+          K1=K1S(I,K2)
+          IF(K1.EQ.1.OR.K1.EQ.KM1-1) THEN
+            Z2S=Z2(1+(I-1)*IXZ2+(K2-1)*KXZ2)
+            Z1A=Z1(1+(I-1)*IXZ1+(K1-1)*KXZ1)
+            Z1B=Z1(1+(I-1)*IXZ1+(K1+0)*KXZ1)
+            FFA(I)=(Z2S-Z1B)/(Z1A-Z1B)
+            FFB(I)=(Z2S-Z1A)/(Z1B-Z1A)
+            GGA(I)=1/(Z1A-Z1B)
+            GGB(I)=1/(Z1B-Z1A)
+          ELSEIF(K1.GT.1.AND.K1.LT.KM1-1) THEN
+            Z2S=Z2(1+(I-1)*IXZ2+(K2-1)*KXZ2)
+            Z1A=Z1(1+(I-1)*IXZ1+(K1-2)*KXZ1)
+            Z1B=Z1(1+(I-1)*IXZ1+(K1-1)*KXZ1)
+            Z1C=Z1(1+(I-1)*IXZ1+(K1+0)*KXZ1)
+            Z1D=Z1(1+(I-1)*IXZ1+(K1+1)*KXZ1)
+            FFA(I)=(Z2S-Z1B)/(Z1A-Z1B)*                                 &
+                   (Z2S-Z1C)/(Z1A-Z1C)*                                 &
+                   (Z2S-Z1D)/(Z1A-Z1D)
+            FFB(I)=(Z2S-Z1A)/(Z1B-Z1A)*                                 &
+                   (Z2S-Z1C)/(Z1B-Z1C)*                                 &
+                   (Z2S-Z1D)/(Z1B-Z1D)
+            FFC(I)=(Z2S-Z1A)/(Z1C-Z1A)*                                 &
+                   (Z2S-Z1B)/(Z1C-Z1B)*                                 &
+                   (Z2S-Z1D)/(Z1C-Z1D)
+            FFD(I)=(Z2S-Z1A)/(Z1D-Z1A)*                                 &
+                   (Z2S-Z1B)/(Z1D-Z1B)*                                 &
+                   (Z2S-Z1C)/(Z1D-Z1C)
+            GGA(I)=        1/(Z1A-Z1B)*                                 &
+                   (Z2S-Z1C)/(Z1A-Z1C)*                                 &
+                   (Z2S-Z1D)/(Z1A-Z1D)+                                 &
+                   (Z2S-Z1B)/(Z1A-Z1B)*                                 &
+                           1/(Z1A-Z1C)*                                 &
+                   (Z2S-Z1D)/(Z1A-Z1D)+                                 &
+                   (Z2S-Z1B)/(Z1A-Z1B)*                                 &
+                   (Z2S-Z1C)/(Z1A-Z1C)*                                 &
+                           1/(Z1A-Z1D)
+            GGB(I)=        1/(Z1B-Z1A)*                                 &
+                   (Z2S-Z1C)/(Z1B-Z1C)*                                 &
+                   (Z2S-Z1D)/(Z1B-Z1D)+                                 &
+                   (Z2S-Z1A)/(Z1B-Z1A)*                                 &
+                           1/(Z1B-Z1C)*                                 &
+                   (Z2S-Z1D)/(Z1B-Z1D)+                                 &
+                   (Z2S-Z1A)/(Z1B-Z1A)*                                 &
+                   (Z2S-Z1C)/(Z1B-Z1C)*                                 &
+                           1/(Z1B-Z1D)
+            GGC(I)=        1/(Z1C-Z1A)*                                 &
+                   (Z2S-Z1B)/(Z1C-Z1B)*                                 &
+                   (Z2S-Z1D)/(Z1C-Z1D)+                                 &
+                   (Z2S-Z1A)/(Z1C-Z1A)*                                 &
+                           1/(Z1C-Z1B)*                                 &
+                   (Z2S-Z1D)/(Z1C-Z1D)+                                 &
+                   (Z2S-Z1A)/(Z1C-Z1A)*                                 &
+                   (Z2S-Z1B)/(Z1C-Z1B)*                                 &
+                           1/(Z1C-Z1D)
+            GGD(I)=        1/(Z1D-Z1A)*                                 &
+                   (Z2S-Z1B)/(Z1D-Z1B)*                                 &
+                   (Z2S-Z1C)/(Z1D-Z1C)+                                 &
+                   (Z2S-Z1A)/(Z1D-Z1A)*                                 &
+                           1/(Z1D-Z1B)*                                 &
+                   (Z2S-Z1C)/(Z1D-Z1C)+                                 &
+                   (Z2S-Z1A)/(Z1D-Z1A)*                                 &
+                   (Z2S-Z1B)/(Z1D-Z1B)*                                 &
+                           1/(Z1D-Z1C)
+          ENDIF
+        ENDDO
+!  INTERPOLATE.
+        DO N=1,NM
+          DO I=1,IM
+            K1=K1S(I,K2)
+            IF(K1.EQ.0) THEN
+              Q2S=Q1(1+(I-1)*IXQ1+(N-1)*NXQ1)
+              J2S=0
+            ELSEIF(K1.EQ.KM1) THEN
+              Q2S=Q1(1+(I-1)*IXQ1+(KM1-1)*KXQ1+(N-1)*NXQ1)
+              J2S=0
+            ELSEIF(K1.EQ.1.OR.K1.EQ.KM1-1) THEN
+              Q1A=Q1(1+(I-1)*IXQ1+(K1-1)*KXQ1+(N-1)*NXQ1)
+              Q1B=Q1(1+(I-1)*IXQ1+(K1+0)*KXQ1+(N-1)*NXQ1)
+              Q2S=FFA(I)*Q1A+FFB(I)*Q1B
+              J2S=GGA(I)*Q1A+GGB(I)*Q1B
+            ELSE
+              Q1A=Q1(1+(I-1)*IXQ1+(K1-2)*KXQ1+(N-1)*NXQ1)
+              Q1B=Q1(1+(I-1)*IXQ1+(K1-1)*KXQ1+(N-1)*NXQ1)
+              Q1C=Q1(1+(I-1)*IXQ1+(K1+0)*KXQ1+(N-1)*NXQ1)
+              Q1D=Q1(1+(I-1)*IXQ1+(K1+1)*KXQ1+(N-1)*NXQ1)
+              Q2S=FFA(I)*Q1A+FFB(I)*Q1B+FFC(I)*Q1C+FFD(I)*Q1D
+              J2S=GGA(I)*Q1A+GGB(I)*Q1B+GGC(I)*Q1C+GGD(I)*Q1D
+              IF(Q2S.LT.MIN(Q1B,Q1C)) THEN
+                Q2S=MIN(Q1B,Q1C)
+                J2S=0
+              ELSEIF(Q2S.GT.MAX(Q1B,Q1C)) THEN
+                Q2S=MAX(Q1B,Q1C)
+                J2S=0
+              ENDIF
+            ENDIF
+            Q2(1+(I-1)*IXQ2+(K2-1)*KXQ2+(N-1)*NXQ2)=Q2S
+            J2(1+(I-1)*IXQ2+(K2-1)*KXQ2+(N-1)*NXQ2)=J2S
+          ENDDO
+        ENDDO
+      ENDDO
+!!$OMP END PARALLEL DO
+
+ END SUBROUTINE TERP3
+ end module utils

--- a/src/tref_calc.fd/utils.f90
+++ b/src/tref_calc.fd/utils.f90
@@ -127,9 +127,9 @@
 !C$$$
       REAL ZS(IM),PS(IM),P(IM,KM),T(IM,KM),Q(IM,KM)
       REAL ZSNEW(IM),PSNEW(IM)
-      PARAMETER(BETA=-6.5E-3,EPSILON=1.E-9)
-      PARAMETER(G=9.80665,RD=287.05,RV=461.50)
-      PARAMETER(GOR=G/RD,FV=RV/RD-1.)
+      real, parameter :: BETA = -6.5E-3, EPSILON = 1.E-9
+      real, parameter :: G = 9.80665, RD = 287.05, RV = 461.50
+      real, parameter :: GOR = G/RD, FV = RV/RD-1.
       REAL ZU(IM)
       FTV(AT,AQ)=AT*(1+FV*AQ)
       FGAM(APU,ATVU,APD,ATVD)=-GOR*LOG(ATVD/ATVU)/LOG(APD/APU)


### PR DESCRIPTION
# Description
Partially addresses https://github.com/NOAA-EMC/global-workflow/issues/4291

This PR adds a utility to interpolate the GDAS `sfcanl` file to the GCDAS resolution, and computes the difference to produce a `dtfanl` file for use to update the `Tref` variable. 

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Build and ran on Ursa

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
