### PR TITLE
Remove SFS ocean products not requested by CPC

### DIFF
--- a/parm/ocnicepost/ocean_sfs.csv
+++ b/parm/ocnicepost/ocean_sfs.csv
@@ -15,3 +15,4 @@
        'so',3,'Ct' , 'bilinear' , '', '','','Sea Water Salinity','psu',0,0,0,0,0,0,0,0
        'uo',3,'Cu' , 'bilinear' , 'vo' , 'Cv','','Sea Water X Velocity','m s-1',0,0,0,0,0,0,0,0
        'vo',3,'Cv' , 'bilinear' , 'uo' , 'Cu','','Sea Water Y Velocity','m s-1',0,0,0,0,0,0,0,0
+     'ePBL',2,'Ct' , 'bilinear' , '', '','','Surface boundary layer depth','m',0,0,0,0,0,0,0,0

--- a/parm/ocnicepost/ocean_sfs.csv
+++ b/parm/ocnicepost/ocean_sfs.csv
@@ -1,28 +1,17 @@
 ! variable name, dimension, grid location, remapping method, vector pair, grid location of vector pair,gb2 varname,discription,unit,gc1,gc2,gc3,gc4,gc5,gc6,gc7,gc8
       'SSH',2,'Ct' , 'bilinear' , '', '','','Sea Surface Height','m',0,0,0,0,0,0,0,0
       'SST',2,'Ct' , 'bilinear' , '', '','','Sea Surface Temperature','degC',0,0,0,0,0,0,0,0
-      'SSS',2,'Ct' , 'bilinear' , '', '','','Sea Surface Salinity','psu',0,0,0,0,0,0,0,0
-    'speed',2,'Ct' , 'bilinear' , '', '','','Sea Surface Speed','m s-1',0,0,0,0,0,0,0,0
   'MLD_003',2,'Ct' , 'bilinear' , '', '','','Mixed layer depth (delta rho = 0.03)','m',0,0,0,0,0,0,0,0
  'MLD_0125',2,'Ct' , 'bilinear' , '', '','','Mixed layer depth (delta rho = 0.125)','m',0,0,0,0,0,0,0,0
    'latent',2,'Ct' , 'conserve' , '', '','','Latent heat flux into ocean due to fusion and evaporation (negative means ocean heat loss)','W m-2',0,0,0,0,0,0,0,0
  'sensible',2,'Ct' , 'conserve' , '', '','','Sensible heat flux into ocean','W m-2',0,0,0,0,0,0,0,0
        'SW',2,'Ct' , 'conserve' , '', '','','Shortwave radiation flux into ocean','W m-2',0,0,0,0,0,0,0,0
        'LW',2,'Ct' , 'conserve' , '', '','','Longwave radiation flux into ocean','W m-2',0,0,0,0,0,0,0,0
-'LwLatSens',2,'Ct' , 'conserve' , '', '','','Combined longwave, latent, and sensible heating at ocean surface','W m-2',0,0,0,0,0,0,0,0
- 'Heat_PmE',2,'Ct' , 'conserve' , '', '','','Heat flux into ocean from mass flux into ocean','W m-2',0,0,0,0,0,0,0,0
       'SSU',2,'Cu' , 'bilinear' , 'SSV'  , 'Cv','','Sea Surface Zonal Velocity','m s-1',0,0,0,0,0,0,0,0
       'SSV',2,'Cv' , 'bilinear' , 'SSU'  , 'Cu','','Sea Surface Meridional Velocity','m s-1',0,0,0,0,0,0,0,0
      'taux',2,'Cu' , 'conserve' , 'tauy' , 'Cv','','Zonal surface stress from ocean interactions with atmos and ice','Pa',0,0,0,0,0,0,0,0
      'tauy',2,'Cv' , 'conserve' , 'taux' , 'Cu','','Meridional surface stress ocean interactions with atmos and ice','Pa',0,0,0,0,0,0,0,0
-     'tob', 2,'Ct' , 'bilinear' , '', '','','Sea Water Potential Temperature at Sea Floor','degC',0,0,0,0,0,0,0,0
      'temp',3,'Ct' , 'bilinear' , '', '','','Potential Temperature','degC',0,0,0,0,0,0,0,0
        'so',3,'Ct' , 'bilinear' , '', '','','Sea Water Salinity','psu',0,0,0,0,0,0,0,0
        'uo',3,'Cu' , 'bilinear' , 'vo' , 'Cv','','Sea Water X Velocity','m s-1',0,0,0,0,0,0,0,0
        'vo',3,'Cv' , 'bilinear' , 'uo' , 'Cu','','Sea Water Y Velocity','m s-1',0,0,0,0,0,0,0,0
-   'frazil',2,'Ct' , 'conserve' , '', '','','Heat from frazil formation','W m-2',0,0,0,0,0,0,0,0
-     'ePBL',2,'Ct' , 'bilinear' , '', '','','Surface boundary layer depth','m',0,0,0,0,0,0,0,0
-     'evap',2,'Ct' , 'conserve' , '', '','','Evaporation/condensation at ocean surface (evaporation is negative)','kg m-2 s-1',0,0,0,0,0,0,0,0
-    'lprec',2,'Ct' , 'conserve' , '', '','','Liquid precipitation into ocean','kg m-2 s-1',0,0,0,0,0,0,0,0
-  'lrunoff',2,'Ct' , 'conserve' , '', '','','Liquid runoff (rivers) into ocean','kg m-2 s-1',0,0,0,0,0,0,0,0
-    'fprec',2,'Ct' , 'conserve' , '', '','','Frozen precipitation into ocean','kg m-2 s-1',0,0,0,0,0,0,0,0


### PR DESCRIPTION
# Description
This PR trims the ocean_sfs.csv file for SFS products to keep only the daily and monthly products requested by CPC

Resolves #166 

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
The edited file has been tested in the global-workflow, with ocean products results in Ursa: /scratch3/NCEPDEV/stmp/Yangxing.Zheng/SFS/RUNS/COMROOT/test_1p00_c192mx025/sfs.19940501/00/mem000/products/ocean/netcdf/1p00

# Checklist
- [ x] Any dependent changes have been merged and published
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ x] New and existing tests pass with my changes
- [ x] I have made corresponding changes to the documentation if necessary
