### PR TITLE
Add speed variable to SFS ocean products

### DIFF
--- a/parm/ocnicepost/ocean_sfs.csv
+++ b/parm/ocnicepost/ocean_sfs.csv
@@ -1,6 +1,7 @@
 ! variable name, dimension, grid location, remapping method, vector pair, grid location of vector pair,gb2 varname,discription,unit,gc1,gc2,gc3,gc4,gc5,gc6,gc7,gc8
       'SSH',2,'Ct' , 'bilinear' , '', '','','Sea Surface Height','m',0,0,0,0,0,0,0,0
       'SST',2,'Ct' , 'bilinear' , '', '','','Sea Surface Temperature','degC',0,0,0,0,0,0,0,0
+    'speed',2,'Ct' , 'bilinear' , '', '','','Sea Surface Speed','m s-1',0,0,0,0,0,0,0,0
   'MLD_003',2,'Ct' , 'bilinear' , '', '','','Mixed layer depth (delta rho = 0.03)','m',0,0,0,0,0,0,0,0
  'MLD_0125',2,'Ct' , 'bilinear' , '', '','','Mixed layer depth (delta rho = 0.125)','m',0,0,0,0,0,0,0,0
    'latent',2,'Ct' , 'conserve' , '', '','','Latent heat flux into ocean due to fusion and evaporation (negative means ocean heat loss)','W m-2',0,0,0,0,0,0,0,0


### PR DESCRIPTION
# Description
The speed variable needs to be added to the ocean_sfs.csv file, since the ocean post tool uses this variable when computing the SSU/SSV variables. Speed had been removed previously in PR #167 .

Resolves #168 

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
We've tested this on the global-workflow. SFS ocean products results are in Ursa /scratch3/NCEPDEV/stmp/Yangxing.Zheng/SFS/RUNS/COMROOT/test_1p00_c96mx100/sfs.19940501/00/mem000/products/ocean/netcdf/1p00

# Checklist
- [ x] Any dependent changes have been merged and published
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ x] New and existing tests pass with my changes
- [ x] I have made corresponding changes to the documentation if necessary
