### PR TITLE
Fix bug for ocean vector pairs

### DIFF
--- a/src/ocnicepost.fd/utils_mod.F90
+++ b/src/ocnicepost.fd/utils_mod.F90
@@ -65,30 +65,35 @@ contains
     character(len=20) :: subname = 'packarrays2d'
 
     fields=0.0
-
     if (debug)write(logunit,'(a)')'enter '//trim(subname)
-    ! obtain vector pairs and create packed arrays
+    ! obtain vector pairs
     do n = 1,nflds
-      if (len_trim(vars(n)%var_pair) == 0) then
-        call getfield(trim(filesrc), trim(vars(n)%var_name), dims=(/dims(1),dims(2)/), &
-               field=fields(:,n))
+       if (trim(vars(n)%var_grid) == 'Cu' .or. trim(vars(n)%var_grid) == 'Bu_x') then
+          allocate(vecpair(dims(1)*dims(2),2)); vecpair = 0.0
+          call getvecpair(trim(filesrc), trim(wgtsdir), cosrot, sinrot,   &
+               trim(vars(n)%var_name), trim(vars(n)%var_grid(1:2)), &
+               trim(vars(n)%var_pair), trim(vars(n)%var_pair_grid(1:2)),  &
+               dims=(/dims(1),dims(2)/), vecpair=vecpair)
+       end if
+    end do
 
-      else if (trim(vars(n)%var_grid) == 'Cu' .or. trim(vars(n)%var_grid) == 'Bu_x') then
-        allocate(vecpair(dims(1)*dims(2),2)); vecpair = 0.0
-        call getvecpair(trim(filesrc), trim(wgtsdir), cosrot, sinrot,   &
-                 trim(vars(n)%var_name), trim(vars(n)%var_grid(1:2)), &
-                 trim(vars(n)%var_pair), trim(vars(n)%var_pair_grid(1:2)),  &
-                 dims=(/dims(1),dims(2)/), vecpair=vecpair)
-        if (trim(vars(n)%var_grid) == 'Cu')fields(:,n) = vecpair(:,1)   ! ocn vectors
-        if (trim(vars(n)%var_grid) == 'Bu_x')fields(:,n) = vecpair(:,1) ! ice vectors
-        ! separate loop for y vector before vecpair deallocation
-!        do nn=1,nflds
-	  if (trim(vars(n)%var_grid) == 'Cv')fields(:,n) = vecpair(:,2)   ! ocn vectors
-          if (trim(vars(n)%var_grid) == 'Bu_y')fields(:,n) = vecpair(:,2) ! ice vectors
-!	enddo
-        deallocate(vecpair)
-      end if
-    enddo
+    ! create packed array
+    nn = 0
+    do n = 1,nflds
+       if (len_trim(vars(n)%var_pair) == 0) then
+          nn = nn + 1
+          call getfield(trim(filesrc), trim(vars(n)%var_name), dims=(/dims(1),dims(2)/), &
+               field=fields(:,nn))
+       else ! fill with vector pairs
+          nn = nn+1
+          ! ocn vectors
+          if (trim(vars(n)%var_grid) == 'Cu')fields(:,nn) = vecpair(:,1)
+          if (trim(vars(n)%var_grid) == 'Cv')fields(:,nn) = vecpair(:,2)
+          ! ice vectors
+          if (trim(vars(n)%var_grid) == 'Bu_x')fields(:,nn) = vecpair(:,1)
+          if (trim(vars(n)%var_grid) == 'Bu_y')fields(:,nn) = vecpair(:,2)
+       end if
+    end do
 
     if (debug)write(logunit,'(a)')'exit '//trim(subname)
   end subroutine packarrays2d

--- a/src/ocnicepost.fd/utils_mod.F90
+++ b/src/ocnicepost.fd/utils_mod.F90
@@ -66,16 +66,6 @@ contains
 
     fields=0.0
     if (debug)write(logunit,'(a)')'enter '//trim(subname)
-    ! obtain vector pairs
-    do n = 1,nflds
-       if (trim(vars(n)%var_grid) == 'Cu' .or. trim(vars(n)%var_grid) == 'Bu_x') then
-          allocate(vecpair(dims(1)*dims(2),2)); vecpair = 0.0
-          call getvecpair(trim(filesrc), trim(wgtsdir), cosrot, sinrot,   &
-               trim(vars(n)%var_name), trim(vars(n)%var_grid(1:2)), &
-               trim(vars(n)%var_pair), trim(vars(n)%var_pair_grid(1:2)),  &
-               dims=(/dims(1),dims(2)/), vecpair=vecpair)
-       end if
-    end do
 
     ! create packed array
     nn = 0
@@ -85,13 +75,20 @@ contains
           call getfield(trim(filesrc), trim(vars(n)%var_name), dims=(/dims(1),dims(2)/), &
                field=fields(:,nn))
        else ! fill with vector pairs
-          nn = nn+1
-          ! ocn vectors
-          if (trim(vars(n)%var_grid) == 'Cu')fields(:,nn) = vecpair(:,1)
-          if (trim(vars(n)%var_grid) == 'Cv')fields(:,nn) = vecpair(:,2)
-          ! ice vectors
-          if (trim(vars(n)%var_grid) == 'Bu_x')fields(:,nn) = vecpair(:,1)
-          if (trim(vars(n)%var_grid) == 'Bu_y')fields(:,nn) = vecpair(:,2)
+          nn = nn + 1
+          if (trim(vars(n)%var_grid) == 'Cu' .or. trim(vars(n)%var_grid) == 'Bu_x') then
+            if(allocated(vecpair)) deallocate(vecpair)
+            allocate(vecpair(dims(1)*dims(2),2)); vecpair = 0.0
+            call getvecpair(trim(filesrc), trim(wgtsdir), cosrot, sinrot,   &
+               trim(vars(n)%var_name), trim(vars(n)%var_grid(1:2)), &
+               trim(vars(n)%var_pair), trim(vars(n)%var_pair_grid(1:2)),  &
+               dims=(/dims(1),dims(2)/), vecpair=vecpair)
+            if (trim(vars(n)%var_grid) == 'Cu')fields(:,nn) = vecpair(:,1)    ! ocn vectors
+            if (trim(vars(n)%var_grid) == 'Bu_x')fields(:,nn) = vecpair(:,1)  ! ice vectors
+          else  ! 'Cv' and 'Bu_y'
+            if (trim(vars(n)%var_grid) == 'Cv')fields(:,nn) = vecpair(:,2)    ! ocn vectors
+            if (trim(vars(n)%var_grid) == 'Bu_y')fields(:,nn) = vecpair(:,2)  ! ice vectors
+          endif
        end if
     end do
 


### PR DESCRIPTION
# Description
This PR fixes a bug found in the ocnicepost tool affecting vector pairs. 2d vectors in the 'Cv' grid were coming out with zero values. The bug has been fixed and results confirmed by EMC. Please see [note](https://github.com/NOAA-EMC/gfs-utils/issues/172#issuecomment-3951658315) regarding bug fix.

  Resolves #172 and #174
-->

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- clone build with bug fix in Ursa
- Ran ocnicepost executable on history netcdf file with SFS variables
- results in /scratch4/NCEPDEV/ovp/Karina.Asmar/ocnpost
- file with interpolated variables (SSV and tauy have been fixed) is ocean.1p00.nc
-->

# Checklist
- [x ] Any dependent changes have been merged and published
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ x] New and existing tests pass with my changes
- [ x] I have made corresponding changes to the documentation if necessary
