### PR TITLE
Make W3MOVDAT inputs all real4

### DIFF
--- a/src/syndat_qctropcy.fd/qctropcy.f
+++ b/src/syndat_qctropcy.fd/qctropcy.f
@@ -11301,12 +11301,19 @@ C
 C$$$
       SUBROUTINE YTIME(IYR,DAYZ,IDATE,JUTC)
       DIMENSION JDAT(8)
-      REAL (KIND=4) DAYZ_4
+      REAL (KIND=4) :: DAYZ_4
+      REAL (KIND=4) :: RINC(5)
 
 C Convert DAYZ to real4 for W3EMC
       DAYZ_4 = REAL(DAYZ, KIND=4)
 
-      CALL W3MOVDAT((/DAYZ_4,0.,0.,0.,0./),(/1899,12,31,0,0,0,0,0/),JDAT)
+      RINC(1) = DAYZ_4
+      RINC(2) = 0.0_4
+      RINC(3) = 0.0_4
+      RINC(4) = 0.0_4
+      RINC(5) = 0.0_4
+
+      CALL W3MOVDAT(RINC,(/1899,12,31,0,0,0,0,0/),JDAT)
       IYR = JDAT(1)
       IMO = JDAT(2)
       IDA = JDAT(3)


### PR DESCRIPTION
# Description
This fixes one additional assumed real8 type to be real4 when calling W3MOVDAT.

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Ran a gdas cycle tropcyc_qc job.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes